### PR TITLE
24 p3 cluster

### DIFF
--- a/p3/kyoulee-1-host
+++ b/p3/kyoulee-1-host
@@ -76,7 +76,6 @@ set_mac() { \n\
     fi \n\
 } \n\
 \n\
-
 set_mac \"42:03:00:01:01:01\" \"eth1\" \n\
 " > /usr/local/bin/assign-mac-start
 

--- a/p3/kyoulee-2
+++ b/p3/kyoulee-2
@@ -72,13 +72,14 @@ RUN printf "\n\
 ! \n\
 router bgp 65001 \n\
   bgp router-id 1.1.1.2 \n\
-  neighbor 1.1.1.1 remote-as 1 \n\
+  neighbor 1.1.1.1 remote-as 65001 \n\
   neighbor 1.1.1.1 update-source lo \n\
   address-family ipv4 unicast \n\
     neighbor 1.1.1.1 activate \n\
   exit-address-family \n\
   address-family l2vpn evpn \n\
     neighbor 1.1.1.1 activate \n\
+    advertise-all-vni \n\
   exit-address-family \n\
 exit \n\
 ! \n\
@@ -181,83 +182,39 @@ RUN chmod +x /usr/local/bin/assign-mac-start
 #    to prevent breaking network isolation in GNS3/VXLAn environments.
 #  - Detailed Verification: Outputs the final spanning tree/port status.
 ################################################################################
-RUN printf "#!/bin/sh\n\
-. /usr/local/bin/common-lib.sh\n\
+RUN printf "#!/bin/sh \n\
+/usr/local/bin/common-lib.sh \n\
 \n\
-setup_bridge_with_ip_ports () {\n\
-    local br_name=\$1\n\
-    local br_ip_with_mask=\$2\n\
-    local target_ip=\${br_ip_with_mask%%/*}\n\
-    if [ -z \"\$br_name\" ] || [ -z \"\$br_ip_with_mask\" ]; then\n\
-        echo \"[FATAL] Missing arguments! Usage: setup_bridge_with_ip_ports <br_name> <ip/mask> <ports...>\"\n\
-        return 1\n\
-    fi\n\
-    if ! brctl show \"\$br_name\" >/dev/null 2>&1; then\n\
-        brctl addbr \"\$br_name\" || return 1\n\
-    fi\n\
-    ip link set \"\$br_name\" up\n\
-    local current_ipv4=\$(ip -4 -o addr show \"\$br_name\" | awk '{print \$4}')\n\
-    if [ -z \"\$current_ipv4\" ]; then\n\
-        echo \"[ACTION] \$br_name is clean. Assigning \$br_ip_with_mask...\"\n\
-        ip addr add \"\$br_ip_with_mask\" dev \"\$br_name\"\n\
-    elif echo \"\$current_ipv4\" | grep -q \"\$target_ip\"; then\n\
-        echo \"[SKIP] \$br_name already has the target IP \$target_ip.\"\n\
-    else\n\
-        echo \"[FATAL] \$br_name is ALREADY IN USE with: \$current_ipv4\"\n\
-        echo \"[FATAL] Manual intervention required to avoid service disruption.\"\n\
-        return 1\n\
-    fi\n\
-    shift 2\n\
-    for port in \"\$@\"; do\n\
-        if [ ! -d \"/sys/class/net/\$port\" ]; then \n\
-            echo \"[WARN] Interface $port does not exist. Skipping...\" \n\
-            continue; \n\
-        fi \n\
-        if [ -n \"\$(ip -4 -o addr show \"\$port\")\" ]; then \n\
-            echo \"[ERROR] Port \$port has existing config. Skipping to prevent breakage.\" \n\
-            continue; \n\
-        fi \n\
-        if ! brctl show \"\$br_name\" | grep -q \"\$port\"; then \n\
-            brctl addif \"\$br_name\" \"\$port\"\n\
-        fi\n\
-        ip link set \"\$port\" up\n\
-    done\n\
-    echo \"[STATUS] Final Bridge Configuration for: \$br_name\"\n\
-    log_status brctl show \"\$br_name\"\n\
-    log_status ip -4 -o addr show \"\$br_name\"\n\
-    return 0\n\
-}\n\
-setup_evpn_bridge() {  \n\
+setup_evpn_bridge() { \n\
     local br_name=\$1 \n\
     local vlan_id=\$2 \n\
+    local vlan_local=\$3 \n\
     local vxlan_interface=\"vxlan\${vlan_id}\" \n\
-    if [ -z \"\$br_name\" ] || [ -z \"\$vlan_id\" ]; then \n\ 
-        echo \"[FATAL] Usage: setup_evpn_bridge <br_name> <vlan_id> <host_ports...>\" \n\
+\n\
+    if [ -z \"\$br_name\" ] || [ -z \"\$vlan_id\" ] || [ -z \"\$vlan_local\" ]; then \n\
+        echo \"[FATAL] Usage: setup_evpn_bridge <br_name> <vlan_id> <vlan_local> <host_ports...>\" \n\
         return 1 \n\
     fi \n\
 \n\
-    if ! ip link show \"\$br_name\" >/dev/null 2>&1; then \n\
-        echo \"[ACTION] Creating VLAN-aware bridge: \$br_name\" \n\
-        ip link add dev \"\$br_name\" type bridge vlan_filtering 1 || return 1 \n\
+    if ! ip link show \"\$br_name\" >/dev/null 2>\&1; then \n\
+        echo \"[ACTION] Creating Traditional bridge: \$br_name\" \n\
+        ip link add dev \"\$br_name\" type bridge || return 1 \n\
     fi \n\
     ip link set \"\$br_name\" up \n\
 \n\
-    if [ -d \"/sys/class/net/\$vxlan_interface\" ]; then \n\
-        if ! ip link show \"\$vxlan_interface\" | grep -q \"master \$br_name\"; then \n\
-            ip link set \"\$vxlan_interface\" master \"\$br_name\" \n\
-        fi \n\
-        ip link set \"\$vxlan_interface\" up \n\
-\n\
-        bridge vlan add dev \"\$vxlan_interface\" vid \"\$vlan_id\" \n\
-        echo \"[ACTION] Connected VXLAN \$vxlan_interface to \$br_name with VLAN \$vlan_id\" \n\ 
-    else \n\
-        echo \"[WARN] VXLAN interface \$vxlan_interface not found! (먼저 생성되어 있어야 합니다)\" \n\ 
+   if ! ip link show \"\$vxlan_interface\" >/dev/null 2>\&1; then \n\
+        ip link add dev \$vxlan_interface type vxlan id \$vlan_id dstport 4789 local \$vlan_local nolearning \n\
+        echo \"[ACTION] Connected VXLAN \$vxlan_interface to \$br_name\" \n\
     fi \n\
+    ip link set \"\$vxlan_interface\" up \n\
+    echo \"[ACTION] Activated VXLAN interface: \$vxlan_interface (Status: UP)\" \n\
+    ip link set dev \"\$vxlan_interface\" master \"\$br_name\" \n\
+    echo \"[STATUS] Successfully plugged \$vxlan_interface into bridge \$br_name\" \n\
 \n\
-    shift 2 \n\
+    shift 3 \n\
     for port in \"\$@\"; do \n\
         if [ ! -d \"/sys/class/net/\$port\" ]; then  \n\
-            echo \"[WARN] Interface $port does not exist. Skipping...\"  \n\
+            echo \"[WARN] Interface \$port does not exist. Skipping...\"  \n\
             continue \n\
         fi \n\
 \n\
@@ -265,18 +222,17 @@ setup_evpn_bridge() {  \n\
             ip link set \"\$port\" master \"\$br_name\" \n\
         fi \n\
         ip link set \"\$port\" up \n\
-\n\
-        bridge vlan add dev \"\$port\" vid \"\$vlan_id\" pvid untagged \n\
-        echo \"[ACTION] Connected Host Port $port to \$br_name as Access (VLAN \$vlan_id)\" \n\
+        echo \"[ACTION] Connected Host Port \$port to \$br_name\" \n\
     done \n\
 \n\
-    echo \"[STATUS] Bridge \$br_name updated successfully.\" \n\
+    echo \"[STATUS] Bridge \$br_name updated done.\" \n\
     return 0 \n\
 } \n\
 \n\
-echo \"[SYSTEM] Ethernat Bridge Configuration Starting...\" \n\
-setup_evpn_bridge br0 10 eth1 eth2 eth3 \n\
-echo \"[SYSTEM] Ethernat Bridge Configuration Done.\"\n" > /usr/local/bin/assign-bridge-start
+echo \"[SYSTEM] Ethernat Bridge Configuration Starting...\"\n\
+setup_evpn_bridge br0 10 1.1.1.2 eth1 eth2 eth3 \n\
+echo \"[SYSTEM] Ethernat Bridge Configuration Done.\"\n\
+" > /usr/local/bin/assign-bridge-start
 
 RUN chmod +x /usr/local/bin/assign-bridge-start
 
@@ -333,7 +289,7 @@ RUN chmod +x /usr/local/bin/assign-udhc-start
 RUN printf "#!/bin/sh\n\
 /usr/local/bin/assign-mac-start \n\
 /usr/local/bin/assign-bridge-start \n\
-/usr/local/bin/assign-udhc-start \n\
+# /usr/local/bin/assign-udhc-start \n\
 echo \"Docker Ethernat Setting Done\n\"\n" > /usr/local/bin/docker-ethernat-start
 
 RUN chmod +x /usr/local/bin/docker-ethernat-start

--- a/p3/kyoulee-2-host
+++ b/p3/kyoulee-2-host
@@ -76,8 +76,7 @@ set_mac() { \n\
     fi \n\
 } \n\
 \n\
-
-set_mac \"42:03:00:01:01:01\" \"eth1\" \n\
+set_mac \"42:03:00:01:02:00\" \"eth0\" \n\
 " > /usr/local/bin/assign-mac-start
 
 RUN chmod +x /usr/local/bin/assign-mac-start
@@ -144,7 +143,7 @@ set_gateway() { \n\
 } \n\
 \n\
 echo \"[SYSTEM] Initializing Network Configuration...\"\n\
-set_ip \"20.1.1.1/24\" \"eth1\" || return 1\n\
+set_ip \"20.1.1.2/24\" \"eth0\" || return 1\n\
 # set_gateway \"20.1.1.254\" || return 1\n\
 echo \"[STATUS] Verification:\"\n\
 log_status ip -4 -o addr show eth1 || echo \"[ERROR] eth1 IPv4 verification failed\"\n\

--- a/p3/kyoulee-3
+++ b/p3/kyoulee-3
@@ -51,18 +51,18 @@ RUN sed -i 's/zebra=no/zebra=yes/' /etc/frr/daemons && \
 RUN printf "\n\
 frr version 9.1 \n\
 frr default traditional \n\
-hostname kyoulee-2 \n\
+hostname kyoulee-3 \n\
 log syslog informational \n\
 " > /etc/frr/frr.conf
 
 RUN printf "\n\
 ! \n\
 interface lo \n\
-  ip address 1.1.1.2/32 \n\
+  ip address 1.1.1.3/32 \n\
 exit \n\
-interface eth0 \n\
+interface eth1 \n\
   description TO_SPINE_1 \n\
-  ip address 10.1.1.2/30 \n\
+  ip address 10.1.1.6/30 \n\
   no shutdown \n\
 exit \n\
 ! \n\
@@ -71,7 +71,7 @@ exit \n\
 RUN printf "\n\
 ! \n\
 router bgp 65001 \n\
-  bgp router-id 1.1.1.2 \n\
+  bgp router-id 1.1.1.3 \n\
   neighbor 1.1.1.1 remote-as 1 \n\
   neighbor 1.1.1.1 update-source lo \n\
   address-family ipv4 unicast \n\
@@ -87,12 +87,12 @@ exit \n\
 RUN printf "\n\
 ! \n\
 router ospf \n\
-  ospf router-id 1.1.1.2 \n\
+  ospf router-id 1.1.1.3 \n\
 exit \n\
 interface lo \n\
   ip ospf area 0 \n\
 exit \n\
-interface eth0 \n\
+interface eth1 \n\
   ip ospf area 0 \n\
 exit \n\
 ! \n\
@@ -160,10 +160,10 @@ set_mac() { \n\
     fi \n\
 } \n\
 \n\
-set_mac \"42:03:02:00:03:00\" \"eth0\" \n\
-set_mac \"42:03:02:00:03:01\" \"eth1\" \n\
-set_mac \"42:03:02:00:03:02\" \"eth2\" \n\
-set_mac \"42:03:02:00:03:03\" \"eth3\" \n" > /usr/local/bin/assign-mac-start
+set_mac \"42:03:03:00:03:00\" \"eth0\" \n\
+set_mac \"42:03:03:00:03:01\" \"eth1\" \n\
+set_mac \"42:03:03:00:03:02\" \"eth2\" \n\
+set_mac \"42:03:03:00:03:03\" \"eth3\" \n" > /usr/local/bin/assign-mac-start
 
 RUN chmod +x /usr/local/bin/assign-mac-start
 ################################################################################
@@ -275,7 +275,7 @@ setup_evpn_bridge() {  \n\
 } \n\
 \n\
 echo \"[SYSTEM] Ethernat Bridge Configuration Starting...\" \n\
-setup_evpn_bridge br0 10 eth1 eth2 eth3 \n\
+setup_evpn_bridge br0 10 eth0 eth2 eth3 \n\
 echo \"[SYSTEM] Ethernat Bridge Configuration Done.\"\n" > /usr/local/bin/assign-bridge-start
 
 RUN chmod +x /usr/local/bin/assign-bridge-start

--- a/p3/kyoulee-3
+++ b/p3/kyoulee-3
@@ -72,13 +72,14 @@ RUN printf "\n\
 ! \n\
 router bgp 65001 \n\
   bgp router-id 1.1.1.3 \n\
-  neighbor 1.1.1.1 remote-as 1 \n\
+  neighbor 1.1.1.1 remote-as 65001 \n\
   neighbor 1.1.1.1 update-source lo \n\
   address-family ipv4 unicast \n\
     neighbor 1.1.1.1 activate \n\
   exit-address-family \n\
   address-family l2vpn evpn \n\
     neighbor 1.1.1.1 activate \n\
+    advertise-all-vni \n\
   exit-address-family \n\
 exit \n\
 ! \n\
@@ -227,37 +228,36 @@ setup_bridge_with_ip_ports () {\n\
     log_status ip -4 -o addr show \"\$br_name\"\n\
     return 0\n\
 }\n\
-setup_evpn_bridge() {  \n\
+setup_evpn_bridge() { \n\
     local br_name=\$1 \n\
     local vlan_id=\$2 \n\
+    local vlan_local=\$3 \n\
     local vxlan_interface=\"vxlan\${vlan_id}\" \n\
-    if [ -z \"\$br_name\" ] || [ -z \"\$vlan_id\" ]; then \n\ 
-        echo \"[FATAL] Usage: setup_evpn_bridge <br_name> <vlan_id> <host_ports...>\" \n\
+\n\
+    if [ -z \"\$br_name\" ] || [ -z \"\$vlan_id\" ] || [ -z \"\$vlan_local\" ]; then \n\
+        echo \"[FATAL] Usage: setup_evpn_bridge <br_name> <vlan_id> <vlan_local> <host_ports...>\" \n\
         return 1 \n\
     fi \n\
 \n\
-    if ! ip link show \"\$br_name\" >/dev/null 2>&1; then \n\
-        echo \"[ACTION] Creating VLAN-aware bridge: \$br_name\" \n\
-        ip link add dev \"\$br_name\" type bridge vlan_filtering 1 || return 1 \n\
+    if ! ip link show \"\$br_name\" >/dev/null 2>\&1; then \n\
+        echo \"[ACTION] Creating Traditional bridge: \$br_name\" \n\
+        ip link add dev \"\$br_name\" type bridge || return 1 \n\
     fi \n\
     ip link set \"\$br_name\" up \n\
 \n\
-    if [ -d \"/sys/class/net/\$vxlan_interface\" ]; then \n\
-        if ! ip link show \"\$vxlan_interface\" | grep -q \"master \$br_name\"; then \n\
-            ip link set \"\$vxlan_interface\" master \"\$br_name\" \n\
-        fi \n\
-        ip link set \"\$vxlan_interface\" up \n\
-\n\
-        bridge vlan add dev \"\$vxlan_interface\" vid \"\$vlan_id\" \n\
-        echo \"[ACTION] Connected VXLAN \$vxlan_interface to \$br_name with VLAN \$vlan_id\" \n\ 
-    else \n\
-        echo \"[WARN] VXLAN interface \$vxlan_interface not found! (먼저 생성되어 있어야 합니다)\" \n\ 
+   if ! ip link show \"\$vxlan_interface\" >/dev/null 2>\&1; then \n\
+        ip link add dev \$vxlan_interface type vxlan id \$vlan_id dstport 4789 local \$vlan_local nolearning \n\
+        echo \"[ACTION] Connected VXLAN \$vxlan_interface to \$br_name\" \n\
     fi \n\
+    ip link set \"\$vxlan_interface\" up \n\
+    echo \"[ACTION] Activated VXLAN interface: \$vxlan_interface (Status: UP)\" \n\
+    ip link set dev \"\$vxlan_interface\" master \"\$br_name\" \n\
+    echo \"[STATUS] Successfully plugged \$vxlan_interface into bridge \$br_name\" \n\
 \n\
-    shift 2 \n\
+    shift 3 \n\
     for port in \"\$@\"; do \n\
         if [ ! -d \"/sys/class/net/\$port\" ]; then  \n\
-            echo \"[WARN] Interface $port does not exist. Skipping...\"  \n\
+            echo \"[WARN] Interface \$port does not exist. Skipping...\"  \n\
             continue \n\
         fi \n\
 \n\
@@ -265,17 +265,15 @@ setup_evpn_bridge() {  \n\
             ip link set \"\$port\" master \"\$br_name\" \n\
         fi \n\
         ip link set \"\$port\" up \n\
-\n\
-        bridge vlan add dev \"\$port\" vid \"\$vlan_id\" pvid untagged \n\
-        echo \"[ACTION] Connected Host Port $port to \$br_name as Access (VLAN \$vlan_id)\" \n\
+        echo \"[ACTION] Connected Host Port \$port to \$br_name\" \n\
     done \n\
 \n\
-    echo \"[STATUS] Bridge \$br_name updated successfully.\" \n\
+    echo \"[STATUS] Bridge \$br_name updated done.\" \n\
     return 0 \n\
 } \n\
 \n\
 echo \"[SYSTEM] Ethernat Bridge Configuration Starting...\" \n\
-setup_evpn_bridge br0 10 eth0 eth2 eth3 \n\
+setup_evpn_bridge br0 10 1.1.1.3 eth0 eth2 eth3 \n\
 echo \"[SYSTEM] Ethernat Bridge Configuration Done.\"\n" > /usr/local/bin/assign-bridge-start
 
 RUN chmod +x /usr/local/bin/assign-bridge-start
@@ -333,7 +331,7 @@ RUN chmod +x /usr/local/bin/assign-udhc-start
 RUN printf "#!/bin/sh\n\
 /usr/local/bin/assign-mac-start \n\
 /usr/local/bin/assign-bridge-start \n\
-/usr/local/bin/assign-udhc-start \n\
+# /usr/local/bin/assign-udhc-start \n\
 echo \"Docker Ethernat Setting Done\n\"\n" > /usr/local/bin/docker-ethernat-start
 
 RUN chmod +x /usr/local/bin/docker-ethernat-start

--- a/p3/kyoulee-3-host
+++ b/p3/kyoulee-3-host
@@ -76,8 +76,7 @@ set_mac() { \n\
     fi \n\
 } \n\
 \n\
-
-set_mac \"42:03:00:01:01:01\" \"eth1\" \n\
+set_mac \"42:03:00:01:03:00\" \"eth0\" \n\
 " > /usr/local/bin/assign-mac-start
 
 RUN chmod +x /usr/local/bin/assign-mac-start
@@ -144,7 +143,7 @@ set_gateway() { \n\
 } \n\
 \n\
 echo \"[SYSTEM] Initializing Network Configuration...\"\n\
-set_ip \"20.1.1.1/24\" \"eth1\" || return 1\n\
+set_ip \"20.1.1.3/24\" \"eth0\" || return 1\n\
 # set_gateway \"20.1.1.254\" || return 1\n\
 echo \"[STATUS] Verification:\"\n\
 log_status ip -4 -o addr show eth1 || echo \"[ERROR] eth1 IPv4 verification failed\"\n\

--- a/p3/kyoulee-4
+++ b/p3/kyoulee-4
@@ -72,13 +72,14 @@ RUN printf "\n\
 ! \n\
 router bgp 65001 \n\
   bgp router-id 1.1.1.4 \n\
-  neighbor 1.1.1.1 remote-as 1 \n\
+  neighbor 1.1.1.1 remote-as 65001 \n\
   neighbor 1.1.1.1 update-source lo \n\
   address-family ipv4 unicast \n\
     neighbor 1.1.1.1 activate \n\
   exit-address-family \n\
   address-family l2vpn evpn \n\
     neighbor 1.1.1.1 activate \n\
+    advertise-all-vni \n\
   exit-address-family \n\
 exit \n\
 ! \n\
@@ -228,37 +229,37 @@ setup_bridge_with_ip_ports () {\n\
     log_status ip -4 -o addr show \"\$br_name\"\n\
     return 0\n\
 }\n\
-setup_evpn_bridge() {  \n\
+\n\
+setup_evpn_bridge() { \n\
     local br_name=\$1 \n\
     local vlan_id=\$2 \n\
+    local vlan_local=\$3 \n\
     local vxlan_interface=\"vxlan\${vlan_id}\" \n\
-    if [ -z \"\$br_name\" ] || [ -z \"\$vlan_id\" ]; then \n\ 
-        echo \"[FATAL] Usage: setup_evpn_bridge <br_name> <vlan_id> <host_ports...>\" \n\
+\n\
+    if [ -z \"\$br_name\" ] || [ -z \"\$vlan_id\" ] || [ -z \"\$vlan_local\" ]; then \n\
+        echo \"[FATAL] Usage: setup_evpn_bridge <br_name> <vlan_id> <vlan_local> <host_ports...>\" \n\
         return 1 \n\
     fi \n\
 \n\
-    if ! ip link show \"\$br_name\" >/dev/null 2>&1; then \n\
-        echo \"[ACTION] Creating VLAN-aware bridge: \$br_name\" \n\
-        ip link add dev \"\$br_name\" type bridge vlan_filtering 1 || return 1 \n\
+    if ! ip link show \"\$br_name\" >/dev/null 2>\&1; then \n\
+        echo \"[ACTION] Creating Traditional bridge: \$br_name\" \n\
+        ip link add dev \"\$br_name\" type bridge || return 1 \n\
     fi \n\
     ip link set \"\$br_name\" up \n\
 \n\
-    if [ -d \"/sys/class/net/\$vxlan_interface\" ]; then \n\
-        if ! ip link show \"\$vxlan_interface\" | grep -q \"master \$br_name\"; then \n\
-            ip link set \"\$vxlan_interface\" master \"\$br_name\" \n\
-        fi \n\
-        ip link set \"\$vxlan_interface\" up \n\
-\n\
-        bridge vlan add dev \"\$vxlan_interface\" vid \"\$vlan_id\" \n\
-        echo \"[ACTION] Connected VXLAN \$vxlan_interface to \$br_name with VLAN \$vlan_id\" \n\ 
-    else \n\
-        echo \"[WARN] VXLAN interface \$vxlan_interface not found! (먼저 생성되어 있어야 합니다)\" \n\ 
+   if ! ip link show \"\$vxlan_interface\" >/dev/null 2>\&1; then \n\
+        ip link add dev \$vxlan_interface type vxlan id \$vlan_id dstport 4789 local \$vlan_local nolearning \n\
+        echo \"[ACTION] Connected VXLAN \$vxlan_interface to \$br_name\" \n\
     fi \n\
+    ip link set \"\$vxlan_interface\" up \n\
+    echo \"[ACTION] Activated VXLAN interface: \$vxlan_interface (Status: UP)\" \n\
+    ip link set dev \"\$vxlan_interface\" master \"\$br_name\" \n\
+    echo \"[STATUS] Successfully plugged \$vxlan_interface into bridge \$br_name\" \n\
 \n\
-    shift 2 \n\
+    shift 3 \n\
     for port in \"\$@\"; do \n\
         if [ ! -d \"/sys/class/net/\$port\" ]; then  \n\
-            echo \"[WARN] Interface $port does not exist. Skipping...\"  \n\
+            echo \"[WARN] Interface \$port does not exist. Skipping...\"  \n\
             continue \n\
         fi \n\
 \n\
@@ -266,17 +267,15 @@ setup_evpn_bridge() {  \n\
             ip link set \"\$port\" master \"\$br_name\" \n\
         fi \n\
         ip link set \"\$port\" up \n\
-\n\
-        bridge vlan add dev \"\$port\" vid \"\$vlan_id\" pvid untagged \n\
-        echo \"[ACTION] Connected Host Port $port to \$br_name as Access (VLAN \$vlan_id)\" \n\
+        echo \"[ACTION] Connected Host Port \$port to \$br_name\" \n\
     done \n\
 \n\
-    echo \"[STATUS] Bridge \$br_name updated successfully.\" \n\
+    echo \"[STATUS] Bridge \$br_name updated done.\" \n\
     return 0 \n\
 } \n\
 \n\
 echo \"[SYSTEM] Ethernat Bridge Configuration Starting...\" \n\
-setup_evpn_bridge br0 10 eth0 eth1 eth3 \n\
+setup_evpn_bridge br0 10 1.1.1.4 eth0 eth1 eth3 \n\
 echo \"[SYSTEM] Ethernat Bridge Configuration Done.\"\n" > /usr/local/bin/assign-bridge-start
 
 RUN chmod +x /usr/local/bin/assign-bridge-start
@@ -334,7 +333,7 @@ RUN chmod +x /usr/local/bin/assign-udhc-start
 RUN printf "#!/bin/sh\n\
 /usr/local/bin/assign-mac-start \n\
 /usr/local/bin/assign-bridge-start \n\
-/usr/local/bin/assign-udhc-start \n\
+# /usr/local/bin/assign-udhc-start \n\
 echo \"Docker Ethernat Setting Done\n\"\n" > /usr/local/bin/docker-ethernat-start
 
 RUN chmod +x /usr/local/bin/docker-ethernat-start

--- a/p3/kyoulee-4
+++ b/p3/kyoulee-4
@@ -58,11 +58,11 @@ log syslog informational \n\
 RUN printf "\n\
 ! \n\
 interface lo \n\
-  ip address 1.1.1.2/32 \n\
+  ip address 1.1.1.4/32 \n\
 exit \n\
-interface eth0 \n\
+interface eth2 \n\
   description TO_SPINE_1 \n\
-  ip address 10.1.1.2/30 \n\
+  ip address 10.1.1.10/30 \n\
   no shutdown \n\
 exit \n\
 ! \n\
@@ -71,7 +71,7 @@ exit \n\
 RUN printf "\n\
 ! \n\
 router bgp 65001 \n\
-  bgp router-id 1.1.1.2 \n\
+  bgp router-id 1.1.1.4 \n\
   neighbor 1.1.1.1 remote-as 1 \n\
   neighbor 1.1.1.1 update-source lo \n\
   address-family ipv4 unicast \n\
@@ -87,12 +87,12 @@ exit \n\
 RUN printf "\n\
 ! \n\
 router ospf \n\
-  ospf router-id 1.1.1.2 \n\
+  ospf router-id 1.1.1.4 \n\
 exit \n\
 interface lo \n\
   ip ospf area 0 \n\
 exit \n\
-interface eth0 \n\
+interface eth2 \n\
   ip ospf area 0 \n\
 exit \n\
 ! \n\
@@ -160,12 +160,13 @@ set_mac() { \n\
     fi \n\
 } \n\
 \n\
-set_mac \"42:03:02:00:03:00\" \"eth0\" \n\
-set_mac \"42:03:02:00:03:01\" \"eth1\" \n\
-set_mac \"42:03:02:00:03:02\" \"eth2\" \n\
-set_mac \"42:03:02:00:03:03\" \"eth3\" \n" > /usr/local/bin/assign-mac-start
+set_mac \"42:03:04:00:03:00\" \"eth0\" \n\
+set_mac \"42:03:04:00:03:01\" \"eth1\" \n\
+set_mac \"42:03:04:00:03:02\" \"eth2\" \n\
+set_mac \"42:03:04:00:03:03\" \"eth3\" \n" > /usr/local/bin/assign-mac-start
 
 RUN chmod +x /usr/local/bin/assign-mac-start
+
 ################################################################################
 # STEP: Ethernet Bridge Configuration with Multi-Port Binding
 #
@@ -275,7 +276,7 @@ setup_evpn_bridge() {  \n\
 } \n\
 \n\
 echo \"[SYSTEM] Ethernat Bridge Configuration Starting...\" \n\
-setup_evpn_bridge br0 10 eth1 eth2 eth3 \n\
+setup_evpn_bridge br0 10 eth0 eth1 eth3 \n\
 echo \"[SYSTEM] Ethernat Bridge Configuration Done.\"\n" > /usr/local/bin/assign-bridge-start
 
 RUN chmod +x /usr/local/bin/assign-bridge-start
@@ -293,7 +294,7 @@ RUN chmod +x /usr/local/bin/assign-bridge-start
 #     ensuring non-blocking operation.
 ################################################################################
 
-RUN sed -i -r 's/^#*[[:space:]]*start[[:space:]]+.*/start           20.1.1.2/' /etc/udhcpd.conf && \
+RUN sed -i -r 's/^#*[[:space:]]*start[[:space:]]+.*/start           20.1.1.1/' /etc/udhcpd.conf && \
     sed -i -r 's/^#*[[:space:]]*end[[:space:]]+.*/end             20.1.1.254/' /etc/udhcpd.conf && \
     sed -i -r 's/^#*[[:space:]]*interface[[:space:]]+.*/interface       br0/' /etc/udhcpd.conf && \
     sed -i '/^opt/s/^/#/' /etc/udhcpd.conf && \


### PR DESCRIPTION
#24  close

## Description
Successfully established a BGP EVPN Route Reflector (RR) topology. Verified the correct propagation of EVPN Type-2 (MAC/IP) and Type-3 (IMET) routes between the RR and multiple Leaf nodes.

## Key Features
- **Route Reflector Configuration**: Configured the RR to aggregate and redistribute EVPN routes among Leaf nodes.
- **BGP Peer Establishment**: Verified bidirectional BGP peering sessions between the RR (1.1.1.1) and Leaf nodes (1.1.1.2, 1.1.1.3, 1.1.1.4).
- **EVPN Route Propagation**: 
    - Confirmed the RR holds a complete view of all EVPN prefixes from Leaf nodes.
    - Verified synchronization of Type-2 and Type-3 routes across the control plane.
- **Verification of Network Reachability**: Confirmed that the VTEP IPs and MAC addresses are correctly populated in the BGP L2VPN EVPN table.

## Result

### EVPN Route Table (RR)
All routes from Leaf nodes (1.1.1.2, 1.1.1.3, 1.1.1.4) are reflected correctly.

```vtysh
# show ip bgp summary

IPv4 Unicast Summary (VRF default):
BGP router identifier 1.1.1.1, local AS number 65001 vrf-id 0
BGP table version 0
RIB entries 0, using 0 bytes of memory
Peers 3, using 39 KiB of memory
Peer groups 1, using 64 bytes of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
1.1.1.2         4      65001        12        16        0    0    0 00:05:08            0        0 FRRouting/9.1
1.1.1.3         4      65001        12        16        0    0    0 00:05:08            0        0 FRRouting/9.1
1.1.1.4         4      65001        12        18        0    0    0 00:05:07            0        0 FRRouting/9.1

Total number of neighbors 3

# show bgp l2vpn evpn vni

BGP table version is 4, local router ID is 1.1.1.1
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete
EVPN type-1 prefix: [1]:[EthTag]:[ESI]:[IPlen]:[VTEP-IP]:[Frag-id]
EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-4 prefix: [4]:[ESI]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 1.1.1.2:2
 *>i[2]:[0]:[48]:[42:03:00:01:01:01]
                    1.1.1.2                       100      0 i
                    RT:65001:10 ET:8
 *>i[3]:[0]:[32]:[1.1.1.2]
                    1.1.1.2                       100      0 i
                    RT:65001:10 ET:8
Route Distinguisher: 1.1.1.3:2
 *>i[2]:[0]:[48]:[42:03:00:01:02:00]
                    1.1.1.3                       100      0 i
                    RT:65001:10 ET:8
 *>i[3]:[0]:[32]:[1.1.1.3]
                    1.1.1.3                       100      0 i
                    RT:65001:10 ET:8
Route Distinguisher: 1.1.1.4:2
 *>i[2]:[0]:[48]:[42:03:00:01:03:00]
                    1.1.1.4                       100      0 i
                    RT:65001:10 ET:8
 *>i[3]:[0]:[32]:[1.1.1.4]
                    1.1.1.4                       100      0 i
                    RT:65001:10 ET:8

Displayed 6 out of 6 total prefixes
```

### Leaf Node Verification (1.1.1.2)
Leaf node 1.1.1.2 correctly learns EVPN routes from the RR and advertises its own local routes.

```vtysh
# show ip bgp summary
IPv4 Unicast Summary (VRF default):
BGP router identifier 1.1.1.2, local AS number 65001 vrf-id 0
BGP table version 0
RIB entries 0, using 0 bytes of memory
Peers 1, using 13 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
1.1.1.1         4      65001        18        14        0    0    0 00:07:01            0        0 FRRouting/9.1

Total number of neighbors 1

# show bgp l2vpn evpn vni

BGP table version is 4, local router ID is 1.1.1.2
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete
EVPN type-1 prefix: [1]:[EthTag]:[ESI]:[IPlen]:[VTEP-IP]:[Frag-id]
EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-4 prefix: [4]:[ESI]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 1.1.1.2:2
 *> [2]:[0]:[48]:[42:03:00:01:01:01]
                    1.1.1.2                            32768 i
                    ET:8 RT:65001:10
 *> [3]:[0]:[32]:[1.1.1.2]
                    1.1.1.2                            32768 i
                    ET:8 RT:65001:10
Route Distinguisher: 1.1.1.3:2
 *>i[2]:[0]:[48]:[42:03:00:01:02:00]
                    1.1.1.3                  0    100      0 i
                    RT:65001:10 ET:8
 *>i[3]:[0]:[32]:[1.1.1.3]
                    1.1.1.3                  0    100      0 i
                    RT:65001:10 ET:8
Route Distinguisher: 1.1.1.4:2
 *>i[2]:[0]:[48]:[42:03:00:01:03:00]
                    1.1.1.4                  0    100      0 i
                    RT:65001:10 ET:8
 *>i[3]:[0]:[32]:[1.1.1.4]
                    1.1.1.4                  0    100      0 i
                    RT:65001:10 ET:8

Displayed 6 out of 6 total prefixes
```