### PR TITLE
standardizeing code document wrote

### DIFF
--- a/p1/kyoulee-1_host
+++ b/p1/kyoulee-1_host
@@ -1,5 +1,21 @@
+################################################################################
+# STEP: Base Image Selection & Core Network Packages Installation
+#
+# This layer builds the baseline execution environment for the routing container:
+#  - Uses Alpine Linux 3.19 as a verified, secure, and lightweight footprint.
+#  - Installs BusyBox utilities to provide essential CLI debugging tools.
+################################################################################
 FROM alpine:3.19
 
-RUN apk update && apk add --no-cache busybox
+RUN apk update && apk add --no-cache \
+    busybox \
+    busybox-extras
 
+################################################################################
+# STEP: Container Runtime Execution Entrypoint
+#
+# Configures the default executable context for the container runtime:
+#  - Executes '/sbin/tini' as the formal PID 1 initialization daemon.
+#  - Uses the '--' separator to safely isolate and pass execution control.
+################################################################################
 CMD ["/bin/sh"]

--- a/p1/kyoulee-2
+++ b/p1/kyoulee-2
@@ -1,10 +1,31 @@
+################################################################################
+# STEP: Base Image Selection & Core Network Packages Installation
+#
+# This layer builds the baseline execution environment for the routing container:
+#  - Uses Alpine Linux 3.19 as a verified, secure, and lightweight footprint.
+#  - Installs FRR (Free Range Routing) for enterprise-grade routing protocols.
+#  - Installs BusyBox utilities to provide essential CLI debugging tools.
+#  - Integrates 'tini' as a minimal init system to safely manage zombie processes
+#    and properly forward OS signals within the container lifecycle.
+################################################################################
 FROM alpine:3.19
 
 RUN apk update && apk add --no-cache \
     frr \
     busybox \
+    busybox-extras \
     tini
 
+################################################################################
+# STEP: FRR Daemon Activation & Configuration Initialization
+#
+# This step pre-configures the FRR environment prior to the service launch:
+#  1. Modifies '/etc/frr/daemons' to explicitly enable routing protocols 
+#     (Zebra, BGP, OSPF, IS-IS) and disables the 'watchfrr' supervisor 
+#     to hand over execution control to the container entrypoint.
+#  2. Generates baseline configuration stub files required by the FRR 
+#     daemons to prevent initialization failures during boot.
+################################################################################
 RUN sed -i 's/zebra=no/zebra=yes/' /etc/frr/daemons && \
     sed -i 's/bgpd=no/bgpd=yes/' /etc/frr/daemons && \
     sed -i 's/ospfd=no/ospfd=yes/' /etc/frr/daemons && \
@@ -17,13 +38,33 @@ RUN touch /etc/frr/zebra.conf \
     /etc/frr/isisd.conf \
     /etc/frr/vtysh.conf
 
+################################################################################
+# STEP: Main Container Entrypoint
+#
+# This script serves as the final entrypoint for the container. It orchestrates
+# the network initialization sequence and ensures the container remains active.
+# 
+# The design follows the "Keep-Alive" pattern:
+#  1. Executes the network orchestration sequence (as needed).
+#  2. Leverages 'tail -f' and 'wait' to prevent container exit.
+################################################################################
 RUN printf "#!/bin/sh\n\
+tail -f /dev/null &\n\
+TAIL_PID=$! \n\
 /usr/lib/frr/zebra -d -F traditional -A 127.0.0.1 -s 90000000\n\
 /usr/lib/frr/bgpd -d -F traditional -A 127.0.0.1\n\
 /usr/lib/frr/ospfd -d -F traditional -A 127.0.0.1\n\
 /usr/lib/frr/isisd -d -F traditional -A 127.0.0.1\n\
-tail -f /dev/null\n" > /usr/lib/frr/docker-start
+wait $TAIL_PID \n\
+" > /usr/lib/frr/docker-start
 
 RUN chmod +x /usr/lib/frr/docker-start
 
+################################################################################
+# STEP: Container Runtime Execution Entrypoint
+#
+# Configures the default executable context for the container runtime:
+#  - Executes '/sbin/tini' as the formal PID 1 initialization daemon.
+#  - Uses the '--' separator to safely isolate and pass execution control.
+################################################################################
 CMD ["/sbin/tini", "--", "/usr/lib/frr/docker-start"]


### PR DESCRIPTION
Closed #28 

## Summary

- configured the entrypoint script to launch the FRR daemons first, and then use ⁠tail -f /dev/null⁠ as the foreground process to keep the container alive.
- added documentation comments.

## Result

### Host
```sh
host_kyoulee-1
PID   USER     TIME  COMMAND
    1 root      0:00 /bin/sh
  417 root      0:00 /gns3/bin/busybox sh -c while true; do TERM=vt100 /gns3/bi
  423 root      0:00 /gns3/bin/busybox sh
  448 root      0:00 ps
```

### Router
```sh
routeur-kyoulee
PID   USER     TIME  COMMAND
    1 root      0:00 /sbin/tini -- /usr/lib/frr/docker-start
  417 root      0:00 /gns3/bin/busybox sh -c while true; do TERM=vt100 /gns3/bi
  423 root      0:00 /gns3/bin/busybox sh
  433 root      0:00 {docker-start} /bin/sh /usr/lib/frr/docker-start
  434 root      0:00 tail -f /dev/null
  436 frr       0:00 /usr/lib/frr/zebra -d -F traditional -A 127.0.0.1 -s 90000
  441 frr       0:00 /usr/lib/frr/bgpd -d -F traditional -A 127.0.0.1
  448 frr       0:00 /usr/lib/frr/ospfd -d -F traditional -A 127.0.0.1
  451 frr       0:00 /usr/lib/frr/isisd -d -F traditional -A 127.0.0.1
  454 root      0:00 ps
```
