### PR TITLE
Clean code & Make code Doc

### DIFF
--- a/p3/kyoulee-1
+++ b/p3/kyoulee-1
@@ -1,10 +1,21 @@
+################################################################################
+# STEP: Base Image Selection & Core Network Packages Installation
+#
+# This layer builds the baseline execution environment for the routing container:
+#  - Uses Alpine Linux 3.19 as a verified, secure, and lightweight footprint.
+#  - Installs FRR (Free Range Routing) for enterprise-grade routing protocols.
+#  - Installs BusyBox utilities to provide essential CLI debugging tools.
+#  - Integrates 'tini' as a minimal init system to safely manage zombie processes
+#    and properly forward OS signals within the container lifecycle.
+################################################################################
 FROM alpine:3.19
 
 RUN apk update && apk add --no-cache \
     frr \
     busybox \
     busybox-extras \
-    tini
+    tini \
+    tcpdump
 
 ################################################################################
 # STEP: Common Utility Library Initialization
@@ -17,45 +28,73 @@ RUN apk update && apk add --no-cache \
 #   . /usr/local/bin/common-lib.sh
 #   log_status <command> <args>
 ################################################################################
-RUN printf "#!/bin/sh\n\
-log_msg() {\n\
-    local tag=\$1\n\
+RUN printf '#!/bin/sh \n\
+log_msg() { \n\
+    local tag=$1 \n\
 \n\
-    if [ \$# -lt 2 ]; then\n\
-        echo \"[FATAL] Wrong usage of log_msg!\"\n\
-        echo \"[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]\"\n\
-        return 1\n\
-    fi\n\
-    shift\n\
-    \"\$@\" 2>&1 | sed \"s/^/[\$tag] /\"\n\
-}\n\
+    if [ $# -lt 2 ]; then \n\
+        echo "[FATAL] Wrong usage of log_msg!" \n\
+        echo "[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]" \n\
+        return 1 \n\
+    fi \n\
+    shift \n\
+    echo "$@" 2>&1 | sed "s/^/[$tag] /" \n\
+} \n\
 \n\
-log_status() { log_msg \"STATUS\" \"\$@\"; }\n\
-log_init()   { log_msg \"INIT\" \"\$@\"; }\n\
-log_fatal()   { log_msg \"FATAL\" \"\$@\"; }\n\
-log_error()  { log_msg \"ERROR\" \"\$@\"; }\n" > /usr/local/bin/common-lib.sh && \
-chmod +x /usr/local/bin/common-lib.sh
+log_status() { log_msg "STATUS" "$@"; } \n\
+log_init()   { log_msg "INIT" "$@"; } \n\
+log_system() { log_msg "SYSTEM" "$@"; } \n\
+log_action() { log_msg "ACTION" "$@"; } \n\
+log_success(){ log_msg "SUCCESS" "$@"; } \n\
+log_fatal()  { log_msg "FATAL" "$@"; } \n\
+log_error()  { log_msg "ERROR" "$@"; } \n\
+log_warning(){ log_msg "WARNING" "$@"; } \n\
+' > /usr/local/bin/common-lib.sh
+
+RUN chmod +x /usr/local/bin/common-lib.sh
 
 ################################################################################
-# STEP: FRR (Free Range Routing) Service Initialization
+# STEP: FRR Daemon Activation & Configuration Initialization
 #
-# Enables specific routing protocol daemons (Zebra, BGP, OSPF) by 
-# modifying the service configuration. Zebra acts as the central manager 
-# for the underlying kernel routing table.
-#
+# This step pre-configures the FRR environment prior to the service launch:
+#  1. Modifies '/etc/frr/daemons' to explicitly enable routing protocols 
+#     (Zebra, BGP, OSPF, IS-IS) and disables the 'watchfrr' supervisor 
+#     to hand over execution control to the container entrypoint.
+#  2. Generates baseline configuration stub files required by the FRR 
+#     daemons to prevent initialization failures during boot.
 ################################################################################
 RUN sed -i 's/zebra=no/zebra=yes/' /etc/frr/daemons && \
     sed -i 's/bgpd=no/bgpd=yes/' /etc/frr/daemons && \
-    sed -i 's/ospfd=no/ospfd=yes/' /etc/frr/daemons
-
-RUN printf "\n\
+    sed -i 's/ospfd=no/ospfd=yes/' /etc/frr/daemons && \
+    sed -i 's/isisd=no/isisd=yes/' /etc/frr/daemons && \
+    sed -i 's/watchfrr_options=.*$/watchfrr_options=""/' /etc/frr/daemons
+    
+################################################################################
+# STEP: Spine/Core Node Routing & Control Plane Configuration (FRR)
+#
+# Configures FRRouting (FRR) to act as an iBGP Route Reflector (RR) over an
+# OSPF Area 0 underlay network. This setup establishes the core control plane
+# for distributing EVPN Type 2 (MAC/IP) routes throughout the fabric.
+#
+# 1. Interfaces & Underlay (OSPF):
+#    - Provisions 'lo' (1.1.1.1/32) as the immutable anchor/Router ID.
+#    - Sets up point-to-point links (eth0-eth3) to downstream Leaf switches.
+#    - Advertises all links into OSPF Area 0 to ensure ubiquitous loopback reachability.
+#
+# 2. Control Plane (iBGP EVPN Route Reflector):
+#    - Operates under AS 1 with Cluster ID 1.1.1.100.
+#    - Pools downstream Leaf nodes (1.1.1.2, 1.1.1.3, 1.1.1.4) into a peer-group.
+#    - Uses the persistent 'lo' interface as the BGP session update-source.
+#    - Activates EVPN address-family to reflect Type-2 MAC/IP routes without full-mesh.
+################################################################################
+RUN printf '\n\
 frr version 9.1 \n\
 frr default traditional \n\
 hostname kyoulee-1 \n\
 log syslog informational \n\
-" > /etc/frr/frr.conf
+' > /etc/frr/frr.conf
 
-RUN printf "\n\
+RUN printf '\n\
 !\n\
 interface lo \n\
   ip address 1.1.1.1/32 \n\
@@ -81,21 +120,22 @@ interface eth3 \n\
   no shutdown \n\
 exit \n\
 ! \n\
-" >> /etc/frr/frr.conf
+' >> /etc/frr/frr.conf
 
-RUN printf "\n\
+RUN printf '\n\
 ! \n\
-router bgp 65001 \n\
+router bgp 1 \n\
   bgp router-id 1.1.1.1 \n\
   bgp cluster-id 1.1.1.100 \n\
   neighbor LEAF-GROUP peer-group \n\
-  neighbor LEAF-GROUP remote-as 65001 \n\
+  neighbor LEAF-GROUP remote-as 1 \n\
   neighbor LEAF-GROUP update-source lo \n\
   neighbor 1.1.1.2 peer-group LEAF-GROUP \n\
   neighbor 1.1.1.3 peer-group LEAF-GROUP \n\
   neighbor 1.1.1.4 peer-group LEAF-GROUP \n\
   address-family ipv4 unicast \n\
     neighbor LEAF-GROUP activate \n\
+    neighbor LEAF-GROUP route-reflector-client \n\
   exit-address-family \n\
   address-family l2vpn evpn \n\
     neighbor LEAF-GROUP activate \n\
@@ -103,9 +143,9 @@ router bgp 65001 \n\
   exit-address-family \n\
 exit \n\
 ! \n\
-" >> /etc/frr/frr.conf
+' >> /etc/frr/frr.conf
 
-RUN printf "\n\
+RUN printf '\n\
 ! \n\
 router ospf \n\
   ospf router-id 1.1.1.1 \n\
@@ -126,8 +166,7 @@ interface eth3 \n\
   ip ospf area 0 \n\
 exit \n\
 ! \n\
-" >> /etc/frr/frr.conf
-
+' >> /etc/frr/frr.conf
 
 RUN chown frr:frr /etc/frr/frr.conf && \
     chmod 640 /etc/frr/frr.conf
@@ -139,14 +178,14 @@ RUN chown frr:frr /etc/frr/frr.conf && \
 # Separating this from the main entrypoint allows for cleaner service 
 # management and independent troubleshooting of the routing stack.
 ################################################################################
-RUN printf "#!/bin/sh\n\
+RUN printf '#!/bin/sh\n\
+. /usr/local/bin/common-lib.sh\n\
 \n\
-echo \"[SYSTEM]Launching FRR Routing Stack...\"\n\
+log_system "Launching FRR Routing Stack..." \n\
 /usr/lib/frr/frrinit.sh start \n\
 /usr/lib/frr/frrinit.sh status \n\
-# vtysh -c \"copy running-config startup-config\" \n\
-# vtysh -c \"show running-config\" \n\
-echo \"[SUCCESS]All FRR daemons are now running in the background.\"\n" > /usr/local/bin/setup-frr-daemons
+log_success "All FRR daemons are now running in the background." \n\
+' > /usr/local/bin/setup-frr-daemons
 
 RUN chmod +x /usr/local/bin/setup-frr-daemons
 
@@ -157,64 +196,67 @@ RUN chmod +x /usr/local/bin/setup-frr-daemons
 # interfaces. It ensures the interface state is managed correctly during 
 # the transition and verifies the hardware presence before execution.
 ################################################################################
-RUN printf "#!/bin/sh \n\
-. /usr/local/bin/common-lib.sh\n\
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+setup_mac() { \n\
+    local MAC_ADDR=$1 \n\
+    local INTERFACE=$2 \n\
 \n\
-set_mac() { \n\
-    local mac=\$1 \n\
-    local dev=\$2 \n\
-\n\
-    if [ -z \"\$mac\" ] || [ -z \"\$dev\" ]; then \n\
-        echo \"[FATAL] Missing arguments! Usage: set_mac <mac_address> <device_name>\" \n\
-        return 1 \n\
+    log_system "setup_mac" \n\
+    if [ ! -d "/sys/class/net/$INTERFACE" ]; then \n\
+        log_warning "Interface $INTERFACE not found." && return 0 \n\
     fi \n\
-\n\
-    if [ ! -d \"/sys/class/net/\$dev\" ]; then \n\
-        echo \"[FATAL] Interface \$dev not found.\" \n\
-        return 1 \n\
+    if ! ip link set "$INTERFACE" down ; then \n\
+        log_error "Interface $INTERFACE can not setup downlink" && return 0 \n\
     fi \n\
-\n\
-    local current_mac=\$(cat /sys/class/net/\$dev/address) \n\
-    if [ \"\$current_mac\" = \"\$mac\" ]; then \n\
-        echo \"[SKIP] \$dev already has MAC \$mac.\" \n\
-    else \n\
-        echo \"[ACTION] Changing \$dev MAC from \$current_mac to \$mac...\" \n\
-        ip link set \"\$dev\" down \n\
-        if ip link set \"\$dev\" address \"\$mac\"; then \n\
-            ip link set \"\$dev\" up \n\
-            echo \"[SUCCESS] MAC address updated for \$dev.\" \n\
-        else \n\
-            echo \"[ERROR] Failed to set MAC for \$dev. (Check permissions/validity)\" \n\
-            ip link set \"\$dev\" up \n\
-            return 1 \n\
-        fi \n\
+    if ! ip link set "$INTERFACE" address "$MAC_ADDR"; then \n\
+        log_warning "Interface $INTERFACE setting MAC address failed" && return 0 \n\
     fi \n\
+    if ! ip link set "$INTERFACE" up ; then \n\
+        log_error "Interface $INTERFACE can not setup uplink" && return 1 \n\
+    fi \n\
+    return 0 \n\
 } \n\
 \n\
-set_mac \"42:03:01:00:03:00\" \"eth0\" \n\
-set_mac \"42:03:01:00:03:01\" \"eth1\" \n\
-set_mac \"42:03:01:00:03:02\" \"eth2\" \n\
-set_mac \"42:03:01:00:03:03\" \"eth3\" \n" > /usr/local/bin/assign-mac-start
+setup_mac "42:03:03:00:01:00" eth0 && \n\
+setup_mac "42:03:03:00:01:01" eth1 && \n\
+setup_mac "42:03:03:00:01:02" eth2 && \n\
+setup_mac "42:03:03:00:01:03" eth3 \n\
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "MAC Setting Done" || \n\
+    log_error "assign-mac-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-mac-start
 
 RUN chmod +x /usr/local/bin/assign-mac-start
 
 ################################################################################
-# STEP: Ethernet & VXLAN Infrastructure Orchestration
+# STEP: Ethernet 
 #
 # This script orchestrates the sequential setup of network infrastructure layers.
 # It ensures that local bridging (Layer 2) is established before initializing 
-# VXLAN tunneling (Overlay), following a strictly ordered initialization pattern.
 #
 # Execution Flow:
-#  1. Local Bridge Setup: Configures br0 and binds physical/virtual interfaces.
-#  2. VXLAN Tunneling: Establishes remote L2-over-L3 connectivity.
-#  3. Final Validation: Signals the completion of the network stack.
+#  1. Local MAC Setup: Configures ethernet interfaces and binds MAC address.
 ################################################################################
-RUN printf "#!/bin/sh\n\
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
 /usr/local/bin/assign-mac-start \n\
-echo \"Docker Ethernat Setting Done\n\"\n" > /usr/local/bin/docker-ethernat-start
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "Docker Ethernat Setting Done" || \n\
+    log_error "docker-ethernet-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/docker-ethernet-start
 
-RUN chmod +x /usr/local/bin/docker-ethernat-start
+RUN chmod +x /usr/local/bin/docker-ethernet-start
 
 ################################################################################
 # STEP: Master System Entrypoint & Service Orchestration
@@ -224,8 +266,8 @@ RUN chmod +x /usr/local/bin/docker-ethernat-start
 # architectural integrity:
 #
 # Sequence:
-#  1. Infrastructure Layer: Invokes 'docker-ethernat-start' to configure 
-#     local bridges and VXLAN tunnels.
+#  1. Infrastructure Layer: Invokes 'docker-ethernet-start' to configure 
+#     local ethernet
 #  2. Routing Layer: Invokes 'setup-frr-daemons' to launch the core routing 
 #     stack (Zebra, BGP, etc.) once the network substrate is ready.
 #  3. Interaction Layer: Spawns an infinite busybox shell loop for 
@@ -234,11 +276,12 @@ RUN chmod +x /usr/local/bin/docker-ethernat-start
 # Design Note: Includes a 'tail -f /dev/null' safety lock to prevent 
 # unexpected container termination.
 ################################################################################
-RUN printf "#!/bin/sh\n\
-/usr/local/bin/docker-ethernat-start \n\
+RUN printf '#!/bin/sh \n\
+/usr/local/bin/docker-ethernet-start && \n\
 /usr/local/bin/setup-frr-daemons \n\
 while true; do /bin/busybox sh ; done \n\
-tail -f /dev/null\n" > /usr/lib/frr/docker-start
+tail -f /dev/null \n\
+' > /usr/lib/frr/docker-start
 
 RUN chmod +x /usr/lib/frr/docker-start
 

--- a/p3/kyoulee-1-host
+++ b/p3/kyoulee-1-host
@@ -1,9 +1,17 @@
+################################################################################
+# STEP: Base Image Selection & Core Network Packages Installation
+#
+# This layer builds the baseline execution environment for the routing container:
+#  - Uses Alpine Linux 3.19 as a verified, secure, and lightweight footprint.
+#  - Installs BusyBox utilities to provide essential CLI debugging tools.
+################################################################################
 FROM alpine:3.19
 
 RUN apk update && apk add --no-cache \
     busybox \
     busybox-extras \
-    tini
+    tini \
+    tcpdump
 
 ################################################################################
 # STEP: Common Utility Library Initialization
@@ -16,24 +24,30 @@ RUN apk update && apk add --no-cache \
 #   . /usr/local/bin/common-lib.sh
 #   log_status <command> <args>
 ################################################################################
-RUN printf "#!/bin/sh\n\
-log_msg() {\n\
-    local tag=\$1\n\
+RUN printf '#!/bin/sh \n\
+log_msg() { \n\
+    local tag=$1 \n\
 \n\
-    if [ \$# -lt 2 ]; then\n\
-        echo \"[FATAL] Wrong usage of log_msg!\"\n\
-        echo \"[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]\"\n\
-        return 1\n\
-    fi\n\
-    shift\n\
-    \"\$@\" 2>&1 | sed \"s/^/[\$tag] /\"\n\
-}\n\
+    if [ $# -lt 2 ]; then \n\
+        echo "[FATAL] Wrong usage of log_msg!" \n\
+        echo "[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]" \n\
+        return 1 \n\
+    fi \n\
+    shift \n\
+    echo "$@" 2>&1 | sed "s/^/[$tag] /" \n\
+} \n\
 \n\
-log_status() { log_msg \"STATUS\" \"\$@\"; }\n\
-log_init()   { log_msg \"INIT\" \"\$@\"; }\n\
-log_fatal()   { log_msg \"FATAL\" \"\$@\"; }\n\
-log_error()  { log_msg \"ERROR\" \"\$@\"; }\n" > /usr/local/bin/common-lib.sh && \
-chmod +x /usr/local/bin/common-lib.sh
+log_status() { log_msg "STATUS" "$@"; } \n\
+log_init()   { log_msg "INIT" "$@"; } \n\
+log_system() { log_msg "SYSTEM" "$@"; } \n\
+log_action() { log_msg "ACTION" "$@"; } \n\
+log_success(){ log_msg "SUCCESS" "$@"; } \n\
+log_fatal()  { log_msg "FATAL" "$@"; } \n\
+log_error()  { log_msg "ERROR" "$@"; } \n\
+log_warning(){ log_msg "WARNING" "$@"; } \n\
+' > /usr/local/bin/common-lib.sh
+
+RUN chmod +x /usr/local/bin/common-lib.sh
 
 ################################################################################
 # STEP: MAC Address Configuration Utility
@@ -42,182 +56,123 @@ chmod +x /usr/local/bin/common-lib.sh
 # interfaces. It ensures the interface state is managed correctly during 
 # the transition and verifies the hardware presence before execution.
 ################################################################################
-RUN printf "#!/bin/sh \n\
-. /usr/local/bin/common-lib.sh\n\
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+setup_mac() { \n\
+    local MAC_ADDR=$1 \n\
+    local INTERFACE=$2 \n\
 \n\
-set_mac() { \n\
-    local mac=\$1 \n\
-    local dev=\$2 \n\
-\n\
-    if [ -z \"\$mac\" ] || [ -z \"\$dev\" ]; then \n\
-        echo \"[FATAL] Missing arguments! Usage: set_mac <mac_address> <device_name>\" \n\
-        return 1 \n\
+    log_system "setup_mac" \n\
+    if [ ! -d "/sys/class/net/$INTERFACE" ]; then \n\
+        log_warning "Interface $INTERFACE not found." && return 0 \n\
     fi \n\
-\n\
-    if [ ! -d \"/sys/class/net/\$dev\" ]; then \n\
-        echo \"[FATAL] Interface \$dev not found.\" \n\
-        return 1 \n\
+    if ! ip link set "$INTERFACE" down ; then \n\
+        log_error "Interface $INTERFACE can not setup downlink" && return 0 \n\
     fi \n\
-\n\
-    local current_mac=\$(cat /sys/class/net/\$dev/address) \n\
-    if [ \"\$current_mac\" = \"\$mac\" ]; then \n\
-        echo \"[SKIP] \$dev already has MAC \$mac.\" \n\
-    else \n\
-        echo \"[ACTION] Changing \$dev MAC from \$current_mac to \$mac...\" \n\
-        ip link set \"\$dev\" down \n\
-        if ip link set \"\$dev\" address \"\$mac\"; then \n\
-            ip link set \"\$dev\" up \n\
-            echo \"[SUCCESS] MAC address updated for \$dev.\" \n\
-        else \n\
-            echo \"[ERROR] Failed to set MAC for \$dev. (Check permissions/validity)\" \n\
-            ip link set \"\$dev\" up \n\
-            return 1 \n\
-        fi \n\
+    if ! ip link set "$INTERFACE" address "$MAC_ADDR"; then \n\
+        log_warning "Interface $INTERFACE setting MAC address failed" && return 0 \n\
     fi \n\
+    if ! ip link set "$INTERFACE" up ; then \n\
+        log_error "Interface $INTERFACE can not setup uplink" && return 1 \n\
+    fi \n\
+    return 0 \n\
 } \n\
 \n\
-set_mac \"42:03:00:01:01:01\" \"eth1\" \n\
-" > /usr/local/bin/assign-mac-start
+setup_mac "42:03:01:00:01:00" eth0 && \n\
+setup_mac "42:03:01:00:01:01" eth1 \n\
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "MAC Setting Done" || \n\
+    log_error "assign-mac-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-mac-start
 
 RUN chmod +x /usr/local/bin/assign-mac-start
+
 ################################################################################
 # STEP: Network Interface Configuration
 #
 # Automates the setup of IP addresses and routing tables.
-# Uses idempotent functions (set_ip, set_gateway) to prevent redundant
+# Uses idempotent functions (setup_interface_ip) to prevent redundant
 # configurations and ensure the system state remains consistent.
 ################################################################################
-RUN printf "#!/bin/sh \n\
+RUN printf '#!/bin/sh \n\
 . /usr/local/bin/common-lib.sh\n\
 \n\
-set_ip() { \n\
-    local ip=\$1 \n\
-    local dev=\$2 \n\
-    local target_ip=\${ip%%/*} \n\
+setup_interface_ip() { \n\
+    local LOOPBACK_IP=$1 \n\
+    local INTERFACE=$2 \n\
 \n\
-    if [ -z \"\$ip\" ] || [ -z \"\$dev\" ]; then \n\
-        echo \"[FATAL] Missing arguments! Usage: set_ip <ip/mask> <device_name>\" \n\
-        return 1 \n\
+    log_system "setup_interface_ip" \n\
+    if ! ip link show "$INTERFACE" >/dev/null 2>&1; then \n\
+        log_error "Interface $INTERFACE not found" && return 2 \n\
     fi \n\
-    if [ ! -d \"/sys/class/net/\$dev\" ]; then \n\
-        echo \"[FATAL] Interface \$dev not found.\" \n\
-        return 1 \n\
+    if ip addr show dev "$INTERFACE" | grep -Fq "$LOOPBACK_IP"; then \n\
+        log_warning "IP $LOOPBACK_IP is already assigned to $INTERFACE." && return 0 \n\ \n\
     fi \n\
-    local current_ipv4=\$(ip -4 -o addr show \"\$dev\" | awk '{print \$4}') \n\
-    if [ -z \"\$current_ipv4\" ]; then \n\
-        echo \"[ACTION] \$dev is clean. Assigning \$ip...\" \n\
-        ip addr add \"\$ip\" dev \"\$dev\" && ip link set \"\$dev\" up \n\
-    elif echo \"\$current_ipv4\" | grep -q \"\$target_ip\"; then \n\
-        echo \"[SKIP] \$dev already has the target IP \$target_ip.\" \n\
-        ip link set \"\$dev\" up \n\
-    else \n\
-        echo \"[FATAL] \$dev has CONFLICTING config: \$current_ipv4\" \n\
-        echo \"[FATAL] Automatic flush is disabled for safety. Manual check required.\" \n\
-        return 1 \n\
+    if ! ip addr add "$LOOPBACK_IP" dev "$INTERFACE"; then \n\
+        log_error "Failed to add IP $LOOPBACK_IP to $INTERFACE" && return 2 \n\
     fi \n\
+    ip link set "$INTERFACE" up \n\
+    log_success "Successfully assigned $LOOPBACK_IP to $INTERFACE" \n\
+    return 0 \n\
 } \n\
+setup_interface_ip 20.1.1.1/24 eth1 \n\
 \n\
-set_gateway() { \n\
-    local gw=\$1 \n\
-\n\    
-    if [ -z \"\$gw\" ]; then \n\
-        echo \"[FATAL] Missing arguments! Usage: set_gateway <gateway_ip>\" \n\
-        return 1 \n\
-    fi \n\
-    local current_gw=\$(ip route show default | awk '/default via/ {print \$3}') \n\
-    if [ \"\$current_gw\" = \"\$gw\" ]; then \n\
-        echo \"[SKIP] Default gateway is already set to \$gw.\" \n\
-    elif [ -z \"\$current_gw\" ]; then \n\
-        echo \"[ACTION] No default gateway found. Setting to \$gw...\" \n\
-        if ip route add default via \"\$gw\"; then \n\
-            echo \"[SUCCESS] Default gateway is now \$gw\" \n\
-        else \n\
-            echo \"[ERROR] Failed to set gateway \$gw. (Check reachability)\" \n\
-            return 1 \n\
-        fi \n\
-    else \n\
-        echo \"[FATAL] Default gateway CONFLICT: Current is \$current_gw, Target is \$gw\" \n\
-        echo \"[FATAL] Automatic override is disabled for safety. Manual intervention required.\" \n\
-        return 1 \n\
-    fi \n\
-} \n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "Interface IP Setting Done" || \n\
+    log_error "docker-ip-start error" \n\
 \n\
-echo \"[SYSTEM] Initializing Network Configuration...\"\n\
-set_ip \"20.1.1.1/24\" \"eth1\" || return 1\n\
-# set_gateway \"20.1.1.254\" || return 1\n\
-echo \"[STATUS] Verification:\"\n\
-log_status ip -4 -o addr show eth1 || echo \"[ERROR] eth1 IPv4 verification failed\"\n\
-# ip route | grep default || echo \"[ERROR] Gateway verification failed\"\n\
-echo \"[SUCCESS] All network configurations applied.\"\n" > /usr/local/bin/assign-ip-start
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-ip-start
 
 RUN chmod +x /usr/local/bin/assign-ip-start
 
 ################################################################################
-# STEP: DHCP Service Initialization
+# STEP: Network Orchestration Entrypoint
 #
-# This script provides a modular and idempotent mechanism to enable DHCP for 
-# specified network interfaces. It abstracts the configuration logic by 
-# parsing and activating entries within '/etc/network/interfaces'.
-#
-# Key Features:
-#  1. Dynamic Interface Targeting: Uses a functional approach to configure 
-#     arbitrary interfaces (e.g., eth0, br0).
-#  2. Fail-Fast Integrity Check: Validates the existence of the configuration 
-#     file and target interface before applying changes.
-#  3. Standardized Logging: Integrates with 'common-lib.sh' to provide 
-#     consistent observability across the network setup process.
+# This script acts as a secondary entrypoint to orchestrate multiple network
+# setup scripts (e.g., assign-ip-start). It ensures that all Ethernet-related
+# configurations are executed in the correct sequence before the main process.
 #
 # Usage:
-#   setup_dhcp_interface <interface_name>
+#   Called internally by /usr/local/bin/docker-start
 ################################################################################
-RUN printf "#!/bin/sh \n\
-sed -i -r 's/^#*[[:space:]]*auto_time[[:space:]]+.*/auto_time 60/' /etc/network/interfaces && \
-" > /usr/local/bin/assign-udhc-start
-
-RUN chmod +x /usr/local/bin/assign-udhc-start
-
-################################################################################
-# STEP: Ethernet & VXLAN Infrastructure Orchestration
-#
-# This script orchestrates the sequential setup of network infrastructure layers.
-# It ensures that local bridging (Layer 2) is established before initializing 
-# VXLAN tunneling (Overlay), following a strictly ordered initialization pattern.
-#
-# Execution Flow:
-#  1. Local Bridge Setup: Configures br0 and binds physical/virtual interfaces.
-#  2. VXLAN Tunneling: Establishes remote L2-over-L3 connectivity.
-#  3. Final Validation: Signals the completion of the network stack.
-################################################################################
-RUN printf "#!/bin/sh\n\
+RUN printf '#!/bin/sh\n\
+. /usr/local/bin/common-lib.sh \n\
 /usr/local/bin/assign-mac-start \n\
 /usr/local/bin/assign-ip-start \n\
-/usr/local/bin/assign-udhc-start \n\
-echo \"Docker Ethernat Setting Done\n\"\n" > /usr/local/bin/docker-ethernat-start
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "Docker Ethernat Setting Done" || \n\
+    log_error "docker-ethernet-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/docker-ethernet-start
 
-RUN chmod +x /usr/local/bin/docker-ethernat-start
+RUN chmod +x /usr/local/bin/docker-ethernet-start
 
 ################################################################################
-# STEP: Master System Entrypoint & Service Orchestration
+# STEP: Main Container Entrypoint
 #
-# This script serves as the primary PID 1 process (or its proxy) for the 
-# container. It follows a strictly ordered initialization sequence to ensure 
-# architectural integrity:
-#
-# Sequence:
-#  1. Infrastructure Layer: Invokes 'docker-ethernat-start' to configure 
-#     local bridges and VXLAN tunnels.
-#  2. Routing Layer: Invokes 'setup-frr-daemons' to launch the core routing 
-#     stack (Zebra, BGP, etc.) once the network substrate is ready.
-#  3. Interaction Layer: Spawns an infinite busybox shell loop for 
-#     administrative access and container persistence.
-#
-# Design Note: Includes a 'tail -f /dev/null' safety lock to prevent 
-# unexpected container termination.
+# This script serves as the final entrypoint for the container. It orchestrates
+# the network initialization sequence and ensures the container remains active.
+# 
+# The design follows the "Keep-Alive" pattern:
+#  1. Executes the network orchestration script.
+#  2. Enters an infinite loop to provide an interactive shell environment.
+#  3. Falls back to 'tail -f' to prevent container exit if the shell terminates.
 ################################################################################
-RUN printf "#!/bin/sh\n\
-/usr/local/bin/docker-ethernat-start \n\
+RUN printf '#!/bin/sh \n\
+/usr/local/bin/docker-ethernet-start \n\
 while true; do /bin/busybox sh ; done \n\
-tail -f /dev/null\n" > /usr/local/bin/docker-start
+tail -f /dev/null \n\
+' > /usr/local/bin/docker-start
 
 RUN chmod +x /usr/local/bin/docker-start
 

--- a/p3/kyoulee-2
+++ b/p3/kyoulee-2
@@ -1,10 +1,21 @@
+################################################################################
+# STEP: Base Image Selection & Core Network Packages Installation
+#
+# This layer builds the baseline execution environment for the routing container:
+#  - Uses Alpine Linux 3.19 as a verified, secure, and lightweight footprint.
+#  - Installs FRR (Free Range Routing) for enterprise-grade routing protocols.
+#  - Installs BusyBox utilities to provide essential CLI debugging tools.
+#  - Integrates 'tini' as a minimal init system to safely manage zombie processes
+#    and properly forward OS signals within the container lifecycle.
+################################################################################
 FROM alpine:3.19
 
 RUN apk update && apk add --no-cache \
     frr \
     busybox \
     busybox-extras \
-    tini
+    tini \
+    tcpdump
 
 ################################################################################
 # STEP: Common Utility Library Initialization
@@ -17,45 +28,74 @@ RUN apk update && apk add --no-cache \
 #   . /usr/local/bin/common-lib.sh
 #   log_status <command> <args>
 ################################################################################
-RUN printf "#!/bin/sh\n\
-log_msg() {\n\
-    local tag=\$1\n\
+RUN printf '#!/bin/sh \n\
+log_msg() { \n\
+    local tag=$1 \n\
 \n\
-    if [ \$# -lt 2 ]; then\n\
-        echo \"[FATAL] Wrong usage of log_msg!\"\n\
-        echo \"[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]\"\n\
-        return 1\n\
-    fi\n\
-    shift\n\
-    \"\$@\" 2>&1 | sed \"s/^/[\$tag] /\"\n\
-}\n\
+    if [ $# -lt 2 ]; then \n\
+        echo "[FATAL] Wrong usage of log_msg!" \n\
+        echo "[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]" \n\
+        return 1 \n\
+    fi \n\
+    shift \n\
+    echo "$@" 2>&1 | sed "s/^/[$tag] /" \n\
+} \n\
 \n\
-log_status() { log_msg \"STATUS\" \"\$@\"; }\n\
-log_init()   { log_msg \"INIT\" \"\$@\"; }\n\
-log_fatal()   { log_msg \"FATAL\" \"\$@\"; }\n\
-log_error()  { log_msg \"ERROR\" \"\$@\"; }\n" > /usr/local/bin/common-lib.sh && \
-chmod +x /usr/local/bin/common-lib.sh
+log_status() { log_msg "STATUS" "$@"; } \n\
+log_init()   { log_msg "INIT" "$@"; } \n\
+log_system() { log_msg "SYSTEM" "$@"; } \n\
+log_action() { log_msg "ACTION" "$@"; } \n\
+log_success(){ log_msg "SUCCESS" "$@"; } \n\
+log_fatal()  { log_msg "FATAL" "$@"; } \n\
+log_error()  { log_msg "ERROR" "$@"; } \n\
+log_warning(){ log_msg "WARNING" "$@"; } \n\
+' > /usr/local/bin/common-lib.sh
+
+RUN chmod +x /usr/local/bin/common-lib.sh
 
 ################################################################################
-# STEP: FRR (Free Range Routing) Service Initialization
+# STEP: FRR Daemon Activation & Configuration Initialization
 #
-# Enables specific routing protocol daemons (Zebra, BGP, OSPF) by 
-# modifying the service configuration. Zebra acts as the central manager 
-# for the underlying kernel routing table.
-#
+# This step pre-configures the FRR environment prior to the service launch:
+#  1. Modifies '/etc/frr/daemons' to explicitly enable routing protocols 
+#     (Zebra, BGP, OSPF, IS-IS) and disables the 'watchfrr' supervisor 
+#     to hand over execution control to the container entrypoint.
+#  2. Generates baseline configuration stub files required by the FRR 
+#     daemons to prevent initialization failures during boot.
 ################################################################################
 RUN sed -i 's/zebra=no/zebra=yes/' /etc/frr/daemons && \
     sed -i 's/bgpd=no/bgpd=yes/' /etc/frr/daemons && \
-    sed -i 's/ospfd=no/ospfd=yes/' /etc/frr/daemons
+    sed -i 's/ospfd=no/ospfd=yes/' /etc/frr/daemons && \
+    sed -i 's/isisd=no/isisd=yes/' /etc/frr/daemons && \
+    sed -i 's/watchfrr_options=.*$/watchfrr_options=""/' /etc/frr/daemons
 
-RUN printf "\n\
+################################################################################
+# STEP: Leaf/Access Node Routing & VTEP Control Plane Configuration (FRR)
+#
+# Configures FRRouting (FRR) to act as an EVPN Leaf (VTEP) switch connected to
+# the Spine Route Reflector (1.1.1.1) over an OSPF Area 0 underlay network.
+# This establishing the local tunnel endpoint for VXLAN encapsulation.
+#
+# 1. Interfaces & Underlay (OSPF):
+#    - Provisions 'lo' (1.1.1.2/32) as the immutable VTEP source / Router ID.
+#    - Sets up point-to-point link (eth0) to upstream Spine switch.
+#    - Advertises 'lo' and 'eth0' into OSPF Area 0 for infrastructure reachability.
+#
+# 2. Control Plane (iBGP EVPN Client):
+#    - Establishes an iBGP session under AS 1 peering directly with the Spine/RR.
+#    - Uses the persistent 'lo' interface as the BGP session update-source.
+#    - Activates EVPN address-family to receive/send network reachability.
+#    - Enables 'advertise-all-vni' to automatically export all local VXLAN VNI 
+#      mappings (e.g., VNI 10) to the Route Reflector.
+################################################################################
+RUN printf '\n\
 frr version 9.1 \n\
 frr default traditional \n\
 hostname kyoulee-2 \n\
 log syslog informational \n\
-" > /etc/frr/frr.conf
+' > /etc/frr/frr.conf
 
-RUN printf "\n\
+RUN printf '\n\
 ! \n\
 interface lo \n\
   ip address 1.1.1.2/32 \n\
@@ -66,13 +106,13 @@ interface eth0 \n\
   no shutdown \n\
 exit \n\
 ! \n\
-" >> /etc/frr/frr.conf
+' >> /etc/frr/frr.conf
 
-RUN printf "\n\
+RUN printf '\n\
 ! \n\
-router bgp 65001 \n\
+router bgp 1 \n\
   bgp router-id 1.1.1.2 \n\
-  neighbor 1.1.1.1 remote-as 65001 \n\
+  neighbor 1.1.1.1 remote-as 1 \n\
   neighbor 1.1.1.1 update-source lo \n\
   address-family ipv4 unicast \n\
     neighbor 1.1.1.1 activate \n\
@@ -83,9 +123,9 @@ router bgp 65001 \n\
   exit-address-family \n\
 exit \n\
 ! \n\
-" >> /etc/frr/frr.conf
+' >> /etc/frr/frr.conf
 
-RUN printf "\n\
+RUN printf '\n\
 ! \n\
 router ospf \n\
   ospf router-id 1.1.1.2 \n\
@@ -97,7 +137,7 @@ interface eth0 \n\
   ip ospf area 0 \n\
 exit \n\
 ! \n\
-" >> /etc/frr/frr.conf
+' >> /etc/frr/frr.conf
 
 RUN chown frr:frr /etc/frr/frr.conf && \
     chmod 640 /etc/frr/frr.conf
@@ -109,14 +149,14 @@ RUN chown frr:frr /etc/frr/frr.conf && \
 # Separating this from the main entrypoint allows for cleaner service 
 # management and independent troubleshooting of the routing stack.
 ################################################################################
-RUN printf "#!/bin/sh\n\
+RUN printf '#!/bin/sh\n\
+. /usr/local/bin/common-lib.sh\n\
 \n\
-echo \"[SYSTEM]Launching FRR Routing Stack...\"\n\
+log_system "Launching FRR Routing Stack..." \n\
 /usr/lib/frr/frrinit.sh start \n\
 /usr/lib/frr/frrinit.sh status \n\
-# vtysh -c \"copy running-config startup-config\" \n\
-# vtysh -c \"show running-config\" \n\
-echo \"[SUCCESS]All FRR daemons are now running in the background.\"\n" > /usr/local/bin/setup-frr-daemons
+log_success "All FRR daemons are now running in the background." \n\
+' > /usr/local/bin/setup-frr-daemons
 
 RUN chmod +x /usr/local/bin/setup-frr-daemons
 
@@ -127,152 +167,173 @@ RUN chmod +x /usr/local/bin/setup-frr-daemons
 # interfaces. It ensures the interface state is managed correctly during 
 # the transition and verifies the hardware presence before execution.
 ################################################################################
-RUN printf "#!/bin/sh \n\
-. /usr/local/bin/common-lib.sh\n\
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+setup_mac() { \n\
+    local MAC_ADDR=$1 \n\
+    local INTERFACE=$2 \n\
 \n\
-set_mac() { \n\
-    local mac=\$1 \n\
-    local dev=\$2 \n\
-\n\
-    if [ -z \"\$mac\" ] || [ -z \"\$dev\" ]; then \n\
-        echo \"[FATAL] Missing arguments! Usage: set_mac <mac_address> <device_name>\" \n\
-        return 1 \n\
+    log_system "setup_mac" \n\
+    if [ ! -d "/sys/class/net/$INTERFACE" ]; then \n\
+        log_warning "Interface $INTERFACE not found." && return 0 \n\
     fi \n\
-\n\
-    if [ ! -d \"/sys/class/net/\$dev\" ]; then \n\
-        echo \"[FATAL] Interface \$dev not found.\" \n\
-        return 1 \n\
+    if ! ip link set "$INTERFACE" down ; then \n\
+        log_error "Interface $INTERFACE can not setup downlink" && return 0 \n\
     fi \n\
-\n\
-    local current_mac=\$(cat /sys/class/net/\$dev/address) \n\
-    if [ \"\$current_mac\" = \"\$mac\" ]; then \n\
-        echo \"[SKIP] \$dev already has MAC \$mac.\" \n\
-    else \n\
-        echo \"[ACTION] Changing \$dev MAC from \$current_mac to \$mac...\" \n\
-        ip link set \"\$dev\" down \n\
-        if ip link set \"\$dev\" address \"\$mac\"; then \n\
-            ip link set \"\$dev\" up \n\
-            echo \"[SUCCESS] MAC address updated for \$dev.\" \n\
-        else \n\
-            echo \"[ERROR] Failed to set MAC for \$dev. (Check permissions/validity)\" \n\
-            ip link set \"\$dev\" up \n\
-            return 1 \n\
-        fi \n\
+    if ! ip link set "$INTERFACE" address "$MAC_ADDR"; then \n\
+        log_warning "Interface $INTERFACE setting MAC address failed" && return 0 \n\
     fi \n\
-} \n\
-\n\
-set_mac \"42:03:02:00:03:00\" \"eth0\" \n\
-set_mac \"42:03:02:00:03:01\" \"eth1\" \n\
-set_mac \"42:03:02:00:03:02\" \"eth2\" \n\
-set_mac \"42:03:02:00:03:03\" \"eth3\" \n" > /usr/local/bin/assign-mac-start
-
-RUN chmod +x /usr/local/bin/assign-mac-start
-################################################################################
-# STEP: Ethernet Bridge Configuration with Multi-Port Binding
-#
-# This script orchestrates the creation of a software bridge (Layer 2) and 
-# assigns an IP address (Layer 3) to the bridge interface. It enables 
-# multi-port binding while ensuring strict state validation for each member 
-# interface.
-#
-# Key Features:
-#  - Idempotent Bridge Creation: Uses 'brctl' to verify or create bridge instances.
-#  - IP Conflict Guard: Aborts if the bridge already carries a conflicting IP.
-#  - Port Sanitization: Skips ports that do not exist or have existing L3 configs
-#    to prevent breaking network isolation in GNS3/VXLAn environments.
-#  - Detailed Verification: Outputs the final spanning tree/port status.
-################################################################################
-RUN printf "#!/bin/sh \n\
-/usr/local/bin/common-lib.sh \n\
-\n\
-setup_evpn_bridge() { \n\
-    local br_name=\$1 \n\
-    local vlan_id=\$2 \n\
-    local vlan_local=\$3 \n\
-    local vxlan_interface=\"vxlan\${vlan_id}\" \n\
-\n\
-    if [ -z \"\$br_name\" ] || [ -z \"\$vlan_id\" ] || [ -z \"\$vlan_local\" ]; then \n\
-        echo \"[FATAL] Usage: setup_evpn_bridge <br_name> <vlan_id> <vlan_local> <host_ports...>\" \n\
-        return 1 \n\
+    if ! ip link set "$INTERFACE" up ; then \n\
+        log_error "Interface $INTERFACE can not setup uplink" && return 1 \n\
     fi \n\
-\n\
-    if ! ip link show \"\$br_name\" >/dev/null 2>\&1; then \n\
-        echo \"[ACTION] Creating Traditional bridge: \$br_name\" \n\
-        ip link add dev \"\$br_name\" type bridge || return 1 \n\
-    fi \n\
-    ip link set \"\$br_name\" up \n\
-\n\
-   if ! ip link show \"\$vxlan_interface\" >/dev/null 2>\&1; then \n\
-        ip link add dev \$vxlan_interface type vxlan id \$vlan_id dstport 4789 local \$vlan_local nolearning \n\
-        echo \"[ACTION] Connected VXLAN \$vxlan_interface to \$br_name\" \n\
-    fi \n\
-    ip link set \"\$vxlan_interface\" up \n\
-    echo \"[ACTION] Activated VXLAN interface: \$vxlan_interface (Status: UP)\" \n\
-    ip link set dev \"\$vxlan_interface\" master \"\$br_name\" \n\
-    echo \"[STATUS] Successfully plugged \$vxlan_interface into bridge \$br_name\" \n\
-\n\
-    shift 3 \n\
-    for port in \"\$@\"; do \n\
-        if [ ! -d \"/sys/class/net/\$port\" ]; then  \n\
-            echo \"[WARN] Interface \$port does not exist. Skipping...\"  \n\
-            continue \n\
-        fi \n\
-\n\
-        if ! ip link show \"\$port\" | grep -q \"master \$br_name\"; then \n\
-            ip link set \"\$port\" master \"\$br_name\" \n\
-        fi \n\
-        ip link set \"\$port\" up \n\
-        echo \"[ACTION] Connected Host Port \$port to \$br_name\" \n\
-    done \n\
-\n\
-    echo \"[STATUS] Bridge \$br_name updated done.\" \n\
     return 0 \n\
 } \n\
 \n\
-echo \"[SYSTEM] Ethernat Bridge Configuration Starting...\"\n\
-setup_evpn_bridge br0 10 1.1.1.2 eth1 eth2 eth3 \n\
-echo \"[SYSTEM] Ethernat Bridge Configuration Done.\"\n\
-" > /usr/local/bin/assign-bridge-start
+setup_mac "42:03:03:00:02:00" eth0 && \n\
+setup_mac "42:03:03:00:02:01" eth1 && \n\
+setup_mac "42:03:03:00:02:02" eth2 && \n\
+setup_mac "42:03:03:00:02:03" eth3 \n\
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "MAC Setting Done" || \n\
+    log_error "assign-mac-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-mac-start
+
+RUN chmod +x /usr/local/bin/assign-mac-start
+
+################################################################################
+# STEP: Ethernet Bridge Configuration and Multi-Interface Binding
+#
+# This script creates a software bridge (Layer 2) and binds multiple physical/
+# virtual interfaces to it. It ensures reliable execution through precise state 
+# validation for each member interface.
+#
+# Key Features:
+#  - Idempotent Bridge Checks: Uses native 'ip link' to prevent duplicating bridges.
+#  - Port Sanitization: Validates the existence of each target interface before 
+#    attempting to attach it to the bridge, preventing script crashes.
+################################################################################
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+setup_bridge() { \n\
+    local BR_NAME=$1 \n\
+    shift \n\
+\n\ 
+    log_system "setup_bridge" \n\
+    if ip link show "$BR_NAME" >/dev/null 2>&1; then \n\
+        log_error "$BR_NAME already exists." \n\
+        return 1 \n\
+    fi \n\
+    if ! ip link add "$BR_NAME" type bridge; then \n\
+        log_error "Bridge $BR_NAME not created" && return 2 \n\
+    fi \n\
+    log_status "Created $BR_NAME brige" \n\
+    if ! ip link set dev "$BR_NAME" up; then \n\
+        log_error "$BR_NAME set up fail" && return 2 \n\
+    fi \n\
+    for interface in "$@"; do \n\
+        if ! ip link show "$interface" >/dev/null 2>&1 ; then \n\
+            log_warning "$interface not founded." && continue \n\
+        fi \n\
+        if ! ip link set dev "$interface" master "$BR_NAME"; then \n\
+            log_warning "Failed to set master $interface for $BR_NAME" && continue \n\
+        fi \n\
+    done \n\
+    log_success "Setup bridge $BR_NAME $@" \n\
+    return 0 \n\
+} \n\
+setup_bridge br0 eth1 eth2 eth3 \n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "Bridge Setting Done" || \n\
+    log_error "docker-bridge-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-bridge-start
 
 RUN chmod +x /usr/local/bin/assign-bridge-start
 
 ################################################################################
-# STEP: DHCP Service Initialization
+# STEP: VXLAN Overlay Network and Bridge Binding Configuration
 #
-# This script ensures the persistence of the DHCP lease database and launches
-# the udhcpd daemon on the pre-configured br0 interface.
+# This script establishes a high-performance VXLAN overlay tunnel (Layer 2 over 
+# Layer 3) and integrates it into a local software bridge (br0). It enables 
+# seamless, cross-host container communication across distinct physical nodes.
 #
-# Execution Flow:
-#  1. Environment Preparation: Validates and creates required directories 
-#     for the DHCP lease database.
-#  2. Service Initialization: Launches the udhcpd daemon in the background 
-#     ensuring non-blocking operation.
+# Key Features:
+#  - Idempotent VXLAN Provisioning: Avoids interface duplication by validating 
+#    pre-existing tunnel endpoints with native 'ip link' checks.
+#  - Network Optimization & Acceleration: Explicitly configures UDP checksums 
+#    (udpcsum) and disables IPv6 zero checksum constraints (noudp6zerocsumtx/rx) 
+#    to drastically reduce encapsulation overhead and boost throughput.
+#  - Robust Multi-Component Validation: Ensures that both physical interfaces and 
+#    target software bridges exist and are healthy before committing tunnel attachments.
 ################################################################################
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+setup_vxlan_leaf() { \n\
+    local VTEP_LOCAL_IP=$1 \n\
+    local VNI=$2 \n\
+    local VXLAN_NAME="vxlan$VNI" \n\
+\n\
+    log_system "setup_vxlan" \n\
+    if ! ip -4 addr show dev lo | grep -F -w "$VTEP_LOCAL_IP" >/dev/null 2>&1; then \n\
+        log_warning "Loopback Interface $VTEP_LOCAL_IP not founded" \n\
+    fi \n\
+    if ip link show "$VXLAN_NAME" >/dev/null 2>&1; then \n\
+        log_error "VXLAN $VXLAN_NAME already exists." && return 2 \n\
+    fi \n\
+    if ! ip link add dev "$VXLAN_NAME" type vxlan \
+    id "$VNI" \
+    dstport 4789 \
+    local "$VTEP_LOCAL_IP" \
+    nolearning \
+    udpcsum noudp6zerocsumtx noudp6zerocsumrx ; then \n\
+        log_error "VXLAN $VXLAN_NAME Created fail" && return 2 \n\
+    fi \n\
+    log_status "Created vxlan $VXLAN_NAME" \n\
+    if ! ip link set dev "$VXLAN_NAME" up; then \n\
+        log_error "$VXLAN_NAME set up fail" && return 2 \n\
+    fi \n\
+    log_success "Setup VXLAN $VXLAN_NAME" \n\
+    return 0 \n\
+} \n\
+setup_vxlan_bridge() { \n\
+    local VXLAN_NAME=$1 \n\
+    local BR_NAME=$2 \n\
+\n\
+    log_system "setup_vxlan_bridge" \n\
+    if ! ip link show "$VXLAN_NAME" >/dev/null 2>&1; then \n\
+        log_error "VXLAN $VXLAN_NAME not founded" && return 2 \n\
+    fi \n\
+    if ! ip link show "$BR_NAME" >/dev/null 2>&1; then \n\
+        log_error "Bridge $BR_NAME not founded" && return 2 \n\
+    fi \n\
+    if ! ip link set dev "$VXLAN_NAME" master "$BR_NAME"; then \n\
+        log_error "Failed to set master $BR_NAME for $VXLAN_NAME"&& return 2  \n\
+    fi \n\
+    log_success "Setup VXLAN bridge connected $VXLAN_NAME to $BR_NAME" \n\
+    return 0 \n\
+} \n\
+\n\
+setup_vxlan_leaf 1.1.1.2 10 && \n\
+setup_vxlan_bridge vxlan10 br0 \n\
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "VXLAN Setting Done" || \n\
+    log_error "assign-vxlan-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-vxlan-start
 
-RUN sed -i -r 's/^#*[[:space:]]*start[[:space:]]+.*/start           20.1.1.2/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*end[[:space:]]+.*/end             20.1.1.254/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*interface[[:space:]]+.*/interface       br0/' /etc/udhcpd.conf && \
-    sed -i '/^opt/s/^/#/' /etc/udhcpd.conf && \
-    sed -i '/^option/s/^/#/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*opt[[:space:]]+dns[[:space:]]+[0-9.]+.*/opt     dns     8.8.8.8/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*option[[:space:]]+subnet[[:space:]]+[0-9.]+.*/option  subnet  255.255.255.0/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*opt[[:space:]]+router[[:space:]]+[0-9.]+.*/opt     router  20.1.1.1/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*auto_time[[:space:]]+.*/auto_time 60/' /etc/udhcpd.conf && \
-    sed -i 's/^#*lease_file.*/lease_file \/var\/lib\/misc\/udhcpd.leases/' /etc/udhcpd.conf
-
-RUN touch /var/lib/misc/udhcpd.leases
-
-RUN printf "#!/bin/sh\n\
-udhcpd -f /etc/udhcpd.conf > /var/log/udhcpd.log 2>&1 &\n\
-sleep 1\n\
-if pgrep udhcpd > /dev/null; then\n\
-    echo '[SUCCESS] udhcpd is running.'\n\
-else\n\
-    echo '[ERROR] udhcpd failed to start. Check /var/log/udhcpd.log'\n\
-fi\n\
-" > /usr/local/bin/assign-udhc-start
-
-RUN chmod +x /usr/local/bin/assign-udhc-start
+RUN chmod +x /usr/local/bin/assign-vxlan-start
 
 ################################################################################
 # STEP: Ethernet & VXLAN Infrastructure Orchestration
@@ -286,13 +347,22 @@ RUN chmod +x /usr/local/bin/assign-udhc-start
 #  2. VXLAN Tunneling: Establishes remote L2-over-L3 connectivity.
 #  3. Final Validation: Signals the completion of the network stack.
 ################################################################################
-RUN printf "#!/bin/sh\n\
-/usr/local/bin/assign-mac-start \n\
-/usr/local/bin/assign-bridge-start \n\
-# /usr/local/bin/assign-udhc-start \n\
-echo \"Docker Ethernat Setting Done\n\"\n" > /usr/local/bin/docker-ethernat-start
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+/usr/local/bin/assign-mac-start && \n\
+/usr/local/bin/assign-bridge-start && \n\
+/usr/local/bin/assign-vxlan-start \n\
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "Docker Ethernat Setting Done" || \n\
+    log_error "docker-ethernet-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/docker-ethernet-start
 
-RUN chmod +x /usr/local/bin/docker-ethernat-start
+RUN chmod +x /usr/local/bin/docker-ethernet-start
 
 ################################################################################
 # STEP: Master System Entrypoint & Service Orchestration
@@ -302,7 +372,7 @@ RUN chmod +x /usr/local/bin/docker-ethernat-start
 # architectural integrity:
 #
 # Sequence:
-#  1. Infrastructure Layer: Invokes 'docker-ethernat-start' to configure 
+#  1. Infrastructure Layer: Invokes 'docker-ethernet-start' to configure 
 #     local bridges and VXLAN tunnels.
 #  2. Routing Layer: Invokes 'setup-frr-daemons' to launch the core routing 
 #     stack (Zebra, BGP, etc.) once the network substrate is ready.
@@ -312,11 +382,12 @@ RUN chmod +x /usr/local/bin/docker-ethernat-start
 # Design Note: Includes a 'tail -f /dev/null' safety lock to prevent 
 # unexpected container termination.
 ################################################################################
-RUN printf "#!/bin/sh\n\
-/usr/local/bin/docker-ethernat-start \n\
+RUN printf '#!/bin/sh \n\
+/usr/local/bin/docker-ethernet-start && \n\
 /usr/local/bin/setup-frr-daemons \n\
 while true; do /bin/busybox sh ; done \n\
-tail -f /dev/null\n" > /usr/lib/frr/docker-start
+tail -f /dev/null \n\
+' > /usr/lib/frr/docker-start
 
 RUN chmod +x /usr/lib/frr/docker-start
 

--- a/p3/kyoulee-2-host
+++ b/p3/kyoulee-2-host
@@ -1,9 +1,17 @@
+################################################################################
+# STEP: Base Image Selection & Core Network Packages Installation
+#
+# This layer builds the baseline execution environment for the routing container:
+#  - Uses Alpine Linux 3.19 as a verified, secure, and lightweight footprint.
+#  - Installs BusyBox utilities to provide essential CLI debugging tools.
+################################################################################
 FROM alpine:3.19
 
 RUN apk update && apk add --no-cache \
     busybox \
     busybox-extras \
-    tini
+    tini \
+    tcpdump
 
 ################################################################################
 # STEP: Common Utility Library Initialization
@@ -16,24 +24,30 @@ RUN apk update && apk add --no-cache \
 #   . /usr/local/bin/common-lib.sh
 #   log_status <command> <args>
 ################################################################################
-RUN printf "#!/bin/sh\n\
-log_msg() {\n\
-    local tag=\$1\n\
+RUN printf '#!/bin/sh \n\
+log_msg() { \n\
+    local tag=$1 \n\
 \n\
-    if [ \$# -lt 2 ]; then\n\
-        echo \"[FATAL] Wrong usage of log_msg!\"\n\
-        echo \"[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]\"\n\
-        return 1\n\
-    fi\n\
-    shift\n\
-    \"\$@\" 2>&1 | sed \"s/^/[\$tag] /\"\n\
-}\n\
+    if [ $# -lt 2 ]; then \n\
+        echo "[FATAL] Wrong usage of log_msg!" \n\
+        echo "[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]" \n\
+        return 1 \n\
+    fi \n\
+    shift \n\
+    echo "$@" 2>&1 | sed "s/^/[$tag] /" \n\
+} \n\
 \n\
-log_status() { log_msg \"STATUS\" \"\$@\"; }\n\
-log_init()   { log_msg \"INIT\" \"\$@\"; }\n\
-log_fatal()   { log_msg \"FATAL\" \"\$@\"; }\n\
-log_error()  { log_msg \"ERROR\" \"\$@\"; }\n" > /usr/local/bin/common-lib.sh && \
-chmod +x /usr/local/bin/common-lib.sh
+log_status() { log_msg "STATUS" "$@"; } \n\
+log_init()   { log_msg "INIT" "$@"; } \n\
+log_system() { log_msg "SYSTEM" "$@"; } \n\
+log_action() { log_msg "ACTION" "$@"; } \n\
+log_success(){ log_msg "SUCCESS" "$@"; } \n\
+log_fatal()  { log_msg "FATAL" "$@"; } \n\
+log_error()  { log_msg "ERROR" "$@"; } \n\
+log_warning(){ log_msg "WARNING" "$@"; } \n\
+' > /usr/local/bin/common-lib.sh
+
+RUN chmod +x /usr/local/bin/common-lib.sh
 
 ################################################################################
 # STEP: MAC Address Configuration Utility
@@ -42,182 +56,123 @@ chmod +x /usr/local/bin/common-lib.sh
 # interfaces. It ensures the interface state is managed correctly during 
 # the transition and verifies the hardware presence before execution.
 ################################################################################
-RUN printf "#!/bin/sh \n\
-. /usr/local/bin/common-lib.sh\n\
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+setup_mac() { \n\
+    local MAC_ADDR=$1 \n\
+    local INTERFACE=$2 \n\
 \n\
-set_mac() { \n\
-    local mac=\$1 \n\
-    local dev=\$2 \n\
-\n\
-    if [ -z \"\$mac\" ] || [ -z \"\$dev\" ]; then \n\
-        echo \"[FATAL] Missing arguments! Usage: set_mac <mac_address> <device_name>\" \n\
-        return 1 \n\
+    log_system "setup_mac" \n\
+    if [ ! -d "/sys/class/net/$INTERFACE" ]; then \n\
+        log_warning "Interface $INTERFACE not found." && return 0 \n\
     fi \n\
-\n\
-    if [ ! -d \"/sys/class/net/\$dev\" ]; then \n\
-        echo \"[FATAL] Interface \$dev not found.\" \n\
-        return 1 \n\
+    if ! ip link set "$INTERFACE" down ; then \n\
+        log_error "Interface $INTERFACE can not setup downlink" && return 0 \n\
     fi \n\
-\n\
-    local current_mac=\$(cat /sys/class/net/\$dev/address) \n\
-    if [ \"\$current_mac\" = \"\$mac\" ]; then \n\
-        echo \"[SKIP] \$dev already has MAC \$mac.\" \n\
-    else \n\
-        echo \"[ACTION] Changing \$dev MAC from \$current_mac to \$mac...\" \n\
-        ip link set \"\$dev\" down \n\
-        if ip link set \"\$dev\" address \"\$mac\"; then \n\
-            ip link set \"\$dev\" up \n\
-            echo \"[SUCCESS] MAC address updated for \$dev.\" \n\
-        else \n\
-            echo \"[ERROR] Failed to set MAC for \$dev. (Check permissions/validity)\" \n\
-            ip link set \"\$dev\" up \n\
-            return 1 \n\
-        fi \n\
+    if ! ip link set "$INTERFACE" address "$MAC_ADDR"; then \n\
+        log_warning "Interface $INTERFACE setting MAC address failed" && return 0 \n\
     fi \n\
+    if ! ip link set "$INTERFACE" up ; then \n\
+        log_error "Interface $INTERFACE can not setup uplink" && return 1 \n\
+    fi \n\
+    return 0 \n\
 } \n\
 \n\
-set_mac \"42:03:00:01:02:00\" \"eth0\" \n\
-" > /usr/local/bin/assign-mac-start
+setup_mac "42:03:01:00:02:00" eth0 && \n\
+setup_mac "42:03:01:00:02:01" eth1 \n\
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "MAC Setting Done" || \n\
+    log_error "assign-mac-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-mac-start
 
 RUN chmod +x /usr/local/bin/assign-mac-start
+
 ################################################################################
 # STEP: Network Interface Configuration
 #
 # Automates the setup of IP addresses and routing tables.
-# Uses idempotent functions (set_ip, set_gateway) to prevent redundant
+# Uses idempotent functions (setup_interface_ip) to prevent redundant
 # configurations and ensure the system state remains consistent.
 ################################################################################
-RUN printf "#!/bin/sh \n\
+RUN printf '#!/bin/sh \n\
 . /usr/local/bin/common-lib.sh\n\
 \n\
-set_ip() { \n\
-    local ip=\$1 \n\
-    local dev=\$2 \n\
-    local target_ip=\${ip%%/*} \n\
+setup_interface_ip() { \n\
+    local LOOPBACK_IP=$1 \n\
+    local INTERFACE=$2 \n\
 \n\
-    if [ -z \"\$ip\" ] || [ -z \"\$dev\" ]; then \n\
-        echo \"[FATAL] Missing arguments! Usage: set_ip <ip/mask> <device_name>\" \n\
-        return 1 \n\
+    log_system "setup_interface_ip" \n\
+    if ! ip link show "$INTERFACE" >/dev/null 2>&1; then \n\
+        log_error "Interface $INTERFACE not found" && return 2 \n\
     fi \n\
-    if [ ! -d \"/sys/class/net/\$dev\" ]; then \n\
-        echo \"[FATAL] Interface \$dev not found.\" \n\
-        return 1 \n\
+    if ip addr show dev "$INTERFACE" | grep -Fq "$LOOPBACK_IP"; then \n\
+        log_warning "IP $LOOPBACK_IP is already assigned to $INTERFACE." && return 0 \n\ \n\
     fi \n\
-    local current_ipv4=\$(ip -4 -o addr show \"\$dev\" | awk '{print \$4}') \n\
-    if [ -z \"\$current_ipv4\" ]; then \n\
-        echo \"[ACTION] \$dev is clean. Assigning \$ip...\" \n\
-        ip addr add \"\$ip\" dev \"\$dev\" && ip link set \"\$dev\" up \n\
-    elif echo \"\$current_ipv4\" | grep -q \"\$target_ip\"; then \n\
-        echo \"[SKIP] \$dev already has the target IP \$target_ip.\" \n\
-        ip link set \"\$dev\" up \n\
-    else \n\
-        echo \"[FATAL] \$dev has CONFLICTING config: \$current_ipv4\" \n\
-        echo \"[FATAL] Automatic flush is disabled for safety. Manual check required.\" \n\
-        return 1 \n\
+    if ! ip addr add "$LOOPBACK_IP" dev "$INTERFACE"; then \n\
+        log_error "Failed to add IP $LOOPBACK_IP to $INTERFACE" && return 2 \n\
     fi \n\
+    ip link set "$INTERFACE" up \n\
+    log_success "Successfully assigned $LOOPBACK_IP to $INTERFACE" \n\
+    return 0 \n\
 } \n\
+setup_interface_ip 20.1.1.2/24 eth0 \n\
 \n\
-set_gateway() { \n\
-    local gw=\$1 \n\
-\n\    
-    if [ -z \"\$gw\" ]; then \n\
-        echo \"[FATAL] Missing arguments! Usage: set_gateway <gateway_ip>\" \n\
-        return 1 \n\
-    fi \n\
-    local current_gw=\$(ip route show default | awk '/default via/ {print \$3}') \n\
-    if [ \"\$current_gw\" = \"\$gw\" ]; then \n\
-        echo \"[SKIP] Default gateway is already set to \$gw.\" \n\
-    elif [ -z \"\$current_gw\" ]; then \n\
-        echo \"[ACTION] No default gateway found. Setting to \$gw...\" \n\
-        if ip route add default via \"\$gw\"; then \n\
-            echo \"[SUCCESS] Default gateway is now \$gw\" \n\
-        else \n\
-            echo \"[ERROR] Failed to set gateway \$gw. (Check reachability)\" \n\
-            return 1 \n\
-        fi \n\
-    else \n\
-        echo \"[FATAL] Default gateway CONFLICT: Current is \$current_gw, Target is \$gw\" \n\
-        echo \"[FATAL] Automatic override is disabled for safety. Manual intervention required.\" \n\
-        return 1 \n\
-    fi \n\
-} \n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "Interface IP Setting Done" || \n\
+    log_error "docker-ip-start error" \n\
 \n\
-echo \"[SYSTEM] Initializing Network Configuration...\"\n\
-set_ip \"20.1.1.2/24\" \"eth0\" || return 1\n\
-# set_gateway \"20.1.1.254\" || return 1\n\
-echo \"[STATUS] Verification:\"\n\
-log_status ip -4 -o addr show eth1 || echo \"[ERROR] eth1 IPv4 verification failed\"\n\
-# ip route | grep default || echo \"[ERROR] Gateway verification failed\"\n\
-echo \"[SUCCESS] All network configurations applied.\"\n" > /usr/local/bin/assign-ip-start
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-ip-start
 
 RUN chmod +x /usr/local/bin/assign-ip-start
 
 ################################################################################
-# STEP: DHCP Service Initialization
+# STEP: Network Orchestration Entrypoint
 #
-# This script provides a modular and idempotent mechanism to enable DHCP for 
-# specified network interfaces. It abstracts the configuration logic by 
-# parsing and activating entries within '/etc/network/interfaces'.
-#
-# Key Features:
-#  1. Dynamic Interface Targeting: Uses a functional approach to configure 
-#     arbitrary interfaces (e.g., eth0, br0).
-#  2. Fail-Fast Integrity Check: Validates the existence of the configuration 
-#     file and target interface before applying changes.
-#  3. Standardized Logging: Integrates with 'common-lib.sh' to provide 
-#     consistent observability across the network setup process.
+# This script acts as a secondary entrypoint to orchestrate multiple network
+# setup scripts (e.g., assign-ip-start). It ensures that all Ethernet-related
+# configurations are executed in the correct sequence before the main process.
 #
 # Usage:
-#   setup_dhcp_interface <interface_name>
+#   Called internally by /usr/local/bin/docker-start
 ################################################################################
-RUN printf "#!/bin/sh \n\
-sed -i -r 's/^#*[[:space:]]*auto_time[[:space:]]+.*/auto_time 60/' /etc/network/interfaces && \
-" > /usr/local/bin/assign-udhc-start
-
-RUN chmod +x /usr/local/bin/assign-udhc-start
-
-################################################################################
-# STEP: Ethernet & VXLAN Infrastructure Orchestration
-#
-# This script orchestrates the sequential setup of network infrastructure layers.
-# It ensures that local bridging (Layer 2) is established before initializing 
-# VXLAN tunneling (Overlay), following a strictly ordered initialization pattern.
-#
-# Execution Flow:
-#  1. Local Bridge Setup: Configures br0 and binds physical/virtual interfaces.
-#  2. VXLAN Tunneling: Establishes remote L2-over-L3 connectivity.
-#  3. Final Validation: Signals the completion of the network stack.
-################################################################################
-RUN printf "#!/bin/sh\n\
+RUN printf '#!/bin/sh\n\
+. /usr/local/bin/common-lib.sh \n\
 /usr/local/bin/assign-mac-start \n\
 /usr/local/bin/assign-ip-start \n\
-/usr/local/bin/assign-udhc-start \n\
-echo \"Docker Ethernat Setting Done\n\"\n" > /usr/local/bin/docker-ethernat-start
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "Docker Ethernat Setting Done" || \n\
+    log_error "docker-ethernet-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/docker-ethernet-start
 
-RUN chmod +x /usr/local/bin/docker-ethernat-start
+RUN chmod +x /usr/local/bin/docker-ethernet-start
 
 ################################################################################
-# STEP: Master System Entrypoint & Service Orchestration
+# STEP: Main Container Entrypoint
 #
-# This script serves as the primary PID 1 process (or its proxy) for the 
-# container. It follows a strictly ordered initialization sequence to ensure 
-# architectural integrity:
-#
-# Sequence:
-#  1. Infrastructure Layer: Invokes 'docker-ethernat-start' to configure 
-#     local bridges and VXLAN tunnels.
-#  2. Routing Layer: Invokes 'setup-frr-daemons' to launch the core routing 
-#     stack (Zebra, BGP, etc.) once the network substrate is ready.
-#  3. Interaction Layer: Spawns an infinite busybox shell loop for 
-#     administrative access and container persistence.
-#
-# Design Note: Includes a 'tail -f /dev/null' safety lock to prevent 
-# unexpected container termination.
+# This script serves as the final entrypoint for the container. It orchestrates
+# the network initialization sequence and ensures the container remains active.
+# 
+# The design follows the "Keep-Alive" pattern:
+#  1. Executes the network orchestration script.
+#  2. Enters an infinite loop to provide an interactive shell environment.
+#  3. Falls back to 'tail -f' to prevent container exit if the shell terminates.
 ################################################################################
-RUN printf "#!/bin/sh\n\
-/usr/local/bin/docker-ethernat-start \n\
+RUN printf '#!/bin/sh \n\
+/usr/local/bin/docker-ethernet-start \n\
 while true; do /bin/busybox sh ; done \n\
-tail -f /dev/null\n" > /usr/local/bin/docker-start
+tail -f /dev/null \n\
+' > /usr/local/bin/docker-start
 
 RUN chmod +x /usr/local/bin/docker-start
 

--- a/p3/kyoulee-3
+++ b/p3/kyoulee-3
@@ -1,10 +1,21 @@
+################################################################################
+# STEP: Base Image Selection & Core Network Packages Installation
+#
+# This layer builds the baseline execution environment for the routing container:
+#  - Uses Alpine Linux 3.19 as a verified, secure, and lightweight footprint.
+#  - Installs FRR (Free Range Routing) for enterprise-grade routing protocols.
+#  - Installs BusyBox utilities to provide essential CLI debugging tools.
+#  - Integrates 'tini' as a minimal init system to safely manage zombie processes
+#    and properly forward OS signals within the container lifecycle.
+################################################################################
 FROM alpine:3.19
 
 RUN apk update && apk add --no-cache \
     frr \
     busybox \
     busybox-extras \
-    tini
+    tini \
+    tcpdump
 
 ################################################################################
 # STEP: Common Utility Library Initialization
@@ -17,45 +28,74 @@ RUN apk update && apk add --no-cache \
 #   . /usr/local/bin/common-lib.sh
 #   log_status <command> <args>
 ################################################################################
-RUN printf "#!/bin/sh\n\
-log_msg() {\n\
-    local tag=\$1\n\
+RUN printf '#!/bin/sh \n\
+log_msg() { \n\
+    local tag=$1 \n\
 \n\
-    if [ \$# -lt 2 ]; then\n\
-        echo \"[FATAL] Wrong usage of log_msg!\"\n\
-        echo \"[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]\"\n\
-        return 1\n\
-    fi\n\
-    shift\n\
-    \"\$@\" 2>&1 | sed \"s/^/[\$tag] /\"\n\
-}\n\
+    if [ $# -lt 2 ]; then \n\
+        echo "[FATAL] Wrong usage of log_msg!" \n\
+        echo "[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]" \n\
+        return 1 \n\
+    fi \n\
+    shift \n\
+    echo "$@" 2>&1 | sed "s/^/[$tag] /" \n\
+} \n\
 \n\
-log_status() { log_msg \"STATUS\" \"\$@\"; }\n\
-log_init()   { log_msg \"INIT\" \"\$@\"; }\n\
-log_fatal()   { log_msg \"FATAL\" \"\$@\"; }\n\
-log_error()  { log_msg \"ERROR\" \"\$@\"; }\n" > /usr/local/bin/common-lib.sh && \
-chmod +x /usr/local/bin/common-lib.sh
+log_status() { log_msg "STATUS" "$@"; } \n\
+log_init()   { log_msg "INIT" "$@"; } \n\
+log_system() { log_msg "SYSTEM" "$@"; } \n\
+log_action() { log_msg "ACTION" "$@"; } \n\
+log_success(){ log_msg "SUCCESS" "$@"; } \n\
+log_fatal()  { log_msg "FATAL" "$@"; } \n\
+log_error()  { log_msg "ERROR" "$@"; } \n\
+log_warning(){ log_msg "WARNING" "$@"; } \n\
+' > /usr/local/bin/common-lib.sh
+
+RUN chmod +x /usr/local/bin/common-lib.sh
 
 ################################################################################
-# STEP: FRR (Free Range Routing) Service Initialization
+# STEP: FRR Daemon Activation & Configuration Initialization
 #
-# Enables specific routing protocol daemons (Zebra, BGP, OSPF) by 
-# modifying the service configuration. Zebra acts as the central manager 
-# for the underlying kernel routing table.
-#
+# This step pre-configures the FRR environment prior to the service launch:
+#  1. Modifies '/etc/frr/daemons' to explicitly enable routing protocols 
+#     (Zebra, BGP, OSPF, IS-IS) and disables the 'watchfrr' supervisor 
+#     to hand over execution control to the container entrypoint.
+#  2. Generates baseline configuration stub files required by the FRR 
+#     daemons to prevent initialization failures during boot.
 ################################################################################
 RUN sed -i 's/zebra=no/zebra=yes/' /etc/frr/daemons && \
     sed -i 's/bgpd=no/bgpd=yes/' /etc/frr/daemons && \
-    sed -i 's/ospfd=no/ospfd=yes/' /etc/frr/daemons
+    sed -i 's/ospfd=no/ospfd=yes/' /etc/frr/daemons && \
+    sed -i 's/isisd=no/isisd=yes/' /etc/frr/daemons && \
+    sed -i 's/watchfrr_options=.*$/watchfrr_options=""/' /etc/frr/daemons
 
-RUN printf "\n\
+################################################################################
+# STEP: Leaf/Access Node Routing & VTEP Control Plane Configuration (FRR)
+#
+# Configures FRRouting (FRR) to act as an EVPN Leaf (VTEP) switch connected to
+# the Spine Route Reflector (1.1.1.1) over an OSPF Area 0 underlay network.
+# This establishing the local tunnel endpoint for VXLAN encapsulation.
+#
+# 1. Interfaces & Underlay (OSPF):
+#    - Provisions 'lo' (1.1.1.3/32) as the immutable VTEP source / Router ID.
+#    - Sets up point-to-point link (eth0) to upstream Spine switch.
+#    - Advertises 'lo' and 'eth0' into OSPF Area 0 for infrastructure reachability.
+#
+# 2. Control Plane (iBGP EVPN Client):
+#    - Establishes an iBGP session under AS 1 peering directly with the Spine/RR.
+#    - Uses the persistent 'lo' interface as the BGP session update-source.
+#    - Activates EVPN address-family to receive/send network reachability.
+#    - Enables 'advertise-all-vni' to automatically export all local VXLAN VNI 
+#      mappings (e.g., VNI 10) to the Route Reflector.
+################################################################################
+RUN printf '\n\
 frr version 9.1 \n\
 frr default traditional \n\
 hostname kyoulee-3 \n\
 log syslog informational \n\
-" > /etc/frr/frr.conf
+' > /etc/frr/frr.conf
 
-RUN printf "\n\
+RUN printf '\n\
 ! \n\
 interface lo \n\
   ip address 1.1.1.3/32 \n\
@@ -66,13 +106,13 @@ interface eth1 \n\
   no shutdown \n\
 exit \n\
 ! \n\
-" >> /etc/frr/frr.conf
+' >> /etc/frr/frr.conf
 
-RUN printf "\n\
+RUN printf '\n\
 ! \n\
-router bgp 65001 \n\
+router bgp 1 \n\
   bgp router-id 1.1.1.3 \n\
-  neighbor 1.1.1.1 remote-as 65001 \n\
+  neighbor 1.1.1.1 remote-as 1 \n\
   neighbor 1.1.1.1 update-source lo \n\
   address-family ipv4 unicast \n\
     neighbor 1.1.1.1 activate \n\
@@ -83,9 +123,9 @@ router bgp 65001 \n\
   exit-address-family \n\
 exit \n\
 ! \n\
-" >> /etc/frr/frr.conf
+' >> /etc/frr/frr.conf
 
-RUN printf "\n\
+RUN printf '\n\
 ! \n\
 router ospf \n\
   ospf router-id 1.1.1.3 \n\
@@ -97,7 +137,7 @@ interface eth1 \n\
   ip ospf area 0 \n\
 exit \n\
 ! \n\
-" >> /etc/frr/frr.conf
+' >> /etc/frr/frr.conf
 
 RUN chown frr:frr /etc/frr/frr.conf && \
     chmod 640 /etc/frr/frr.conf
@@ -109,14 +149,14 @@ RUN chown frr:frr /etc/frr/frr.conf && \
 # Separating this from the main entrypoint allows for cleaner service 
 # management and independent troubleshooting of the routing stack.
 ################################################################################
-RUN printf "#!/bin/sh\n\
+RUN printf '#!/bin/sh\n\
+. /usr/local/bin/common-lib.sh\n\
 \n\
-echo \"[SYSTEM]Launching FRR Routing Stack...\"\n\
+log_system "Launching FRR Routing Stack..." \n\
 /usr/lib/frr/frrinit.sh start \n\
 /usr/lib/frr/frrinit.sh status \n\
-# vtysh -c \"copy running-config startup-config\" \n\
-# vtysh -c \"show running-config\" \n\
-echo \"[SUCCESS]All FRR daemons are now running in the background.\"\n" > /usr/local/bin/setup-frr-daemons
+log_success "All FRR daemons are now running in the background." \n\
+' > /usr/local/bin/setup-frr-daemons
 
 RUN chmod +x /usr/local/bin/setup-frr-daemons
 
@@ -127,194 +167,173 @@ RUN chmod +x /usr/local/bin/setup-frr-daemons
 # interfaces. It ensures the interface state is managed correctly during 
 # the transition and verifies the hardware presence before execution.
 ################################################################################
-RUN printf "#!/bin/sh \n\
-. /usr/local/bin/common-lib.sh\n\
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+setup_mac() { \n\
+    local MAC_ADDR=$1 \n\
+    local INTERFACE=$2 \n\
 \n\
-set_mac() { \n\
-    local mac=\$1 \n\
-    local dev=\$2 \n\
-\n\
-    if [ -z \"\$mac\" ] || [ -z \"\$dev\" ]; then \n\
-        echo \"[FATAL] Missing arguments! Usage: set_mac <mac_address> <device_name>\" \n\
-        return 1 \n\
+    log_system "setup_mac" \n\
+    if [ ! -d "/sys/class/net/$INTERFACE" ]; then \n\
+        log_warning "Interface $INTERFACE not found." && return 0 \n\
     fi \n\
-\n\
-    if [ ! -d \"/sys/class/net/\$dev\" ]; then \n\
-        echo \"[FATAL] Interface \$dev not found.\" \n\
-        return 1 \n\
+    if ! ip link set "$INTERFACE" down ; then \n\
+        log_error "Interface $INTERFACE can not setup downlink" && return 0 \n\
     fi \n\
-\n\
-    local current_mac=\$(cat /sys/class/net/\$dev/address) \n\
-    if [ \"\$current_mac\" = \"\$mac\" ]; then \n\
-        echo \"[SKIP] \$dev already has MAC \$mac.\" \n\
-    else \n\
-        echo \"[ACTION] Changing \$dev MAC from \$current_mac to \$mac...\" \n\
-        ip link set \"\$dev\" down \n\
-        if ip link set \"\$dev\" address \"\$mac\"; then \n\
-            ip link set \"\$dev\" up \n\
-            echo \"[SUCCESS] MAC address updated for \$dev.\" \n\
-        else \n\
-            echo \"[ERROR] Failed to set MAC for \$dev. (Check permissions/validity)\" \n\
-            ip link set \"\$dev\" up \n\
-            return 1 \n\
-        fi \n\
+    if ! ip link set "$INTERFACE" address "$MAC_ADDR"; then \n\
+        log_warning "Interface $INTERFACE setting MAC address failed" && return 0 \n\
     fi \n\
-} \n\
-\n\
-set_mac \"42:03:03:00:03:00\" \"eth0\" \n\
-set_mac \"42:03:03:00:03:01\" \"eth1\" \n\
-set_mac \"42:03:03:00:03:02\" \"eth2\" \n\
-set_mac \"42:03:03:00:03:03\" \"eth3\" \n" > /usr/local/bin/assign-mac-start
-
-RUN chmod +x /usr/local/bin/assign-mac-start
-################################################################################
-# STEP: Ethernet Bridge Configuration with Multi-Port Binding
-#
-# This script orchestrates the creation of a software bridge (Layer 2) and 
-# assigns an IP address (Layer 3) to the bridge interface. It enables 
-# multi-port binding while ensuring strict state validation for each member 
-# interface.
-#
-# Key Features:
-#  - Idempotent Bridge Creation: Uses 'brctl' to verify or create bridge instances.
-#  - IP Conflict Guard: Aborts if the bridge already carries a conflicting IP.
-#  - Port Sanitization: Skips ports that do not exist or have existing L3 configs
-#    to prevent breaking network isolation in GNS3/VXLAn environments.
-#  - Detailed Verification: Outputs the final spanning tree/port status.
-################################################################################
-RUN printf "#!/bin/sh\n\
-. /usr/local/bin/common-lib.sh\n\
-\n\
-setup_bridge_with_ip_ports () {\n\
-    local br_name=\$1\n\
-    local br_ip_with_mask=\$2\n\
-    local target_ip=\${br_ip_with_mask%%/*}\n\
-    if [ -z \"\$br_name\" ] || [ -z \"\$br_ip_with_mask\" ]; then\n\
-        echo \"[FATAL] Missing arguments! Usage: setup_bridge_with_ip_ports <br_name> <ip/mask> <ports...>\"\n\
-        return 1\n\
-    fi\n\
-    if ! brctl show \"\$br_name\" >/dev/null 2>&1; then\n\
-        brctl addbr \"\$br_name\" || return 1\n\
-    fi\n\
-    ip link set \"\$br_name\" up\n\
-    local current_ipv4=\$(ip -4 -o addr show \"\$br_name\" | awk '{print \$4}')\n\
-    if [ -z \"\$current_ipv4\" ]; then\n\
-        echo \"[ACTION] \$br_name is clean. Assigning \$br_ip_with_mask...\"\n\
-        ip addr add \"\$br_ip_with_mask\" dev \"\$br_name\"\n\
-    elif echo \"\$current_ipv4\" | grep -q \"\$target_ip\"; then\n\
-        echo \"[SKIP] \$br_name already has the target IP \$target_ip.\"\n\
-    else\n\
-        echo \"[FATAL] \$br_name is ALREADY IN USE with: \$current_ipv4\"\n\
-        echo \"[FATAL] Manual intervention required to avoid service disruption.\"\n\
-        return 1\n\
-    fi\n\
-    shift 2\n\
-    for port in \"\$@\"; do\n\
-        if [ ! -d \"/sys/class/net/\$port\" ]; then \n\
-            echo \"[WARN] Interface $port does not exist. Skipping...\" \n\
-            continue; \n\
-        fi \n\
-        if [ -n \"\$(ip -4 -o addr show \"\$port\")\" ]; then \n\
-            echo \"[ERROR] Port \$port has existing config. Skipping to prevent breakage.\" \n\
-            continue; \n\
-        fi \n\
-        if ! brctl show \"\$br_name\" | grep -q \"\$port\"; then \n\
-            brctl addif \"\$br_name\" \"\$port\"\n\
-        fi\n\
-        ip link set \"\$port\" up\n\
-    done\n\
-    echo \"[STATUS] Final Bridge Configuration for: \$br_name\"\n\
-    log_status brctl show \"\$br_name\"\n\
-    log_status ip -4 -o addr show \"\$br_name\"\n\
-    return 0\n\
-}\n\
-setup_evpn_bridge() { \n\
-    local br_name=\$1 \n\
-    local vlan_id=\$2 \n\
-    local vlan_local=\$3 \n\
-    local vxlan_interface=\"vxlan\${vlan_id}\" \n\
-\n\
-    if [ -z \"\$br_name\" ] || [ -z \"\$vlan_id\" ] || [ -z \"\$vlan_local\" ]; then \n\
-        echo \"[FATAL] Usage: setup_evpn_bridge <br_name> <vlan_id> <vlan_local> <host_ports...>\" \n\
-        return 1 \n\
+    if ! ip link set "$INTERFACE" up ; then \n\
+        log_error "Interface $INTERFACE can not setup uplink" && return 1 \n\
     fi \n\
-\n\
-    if ! ip link show \"\$br_name\" >/dev/null 2>\&1; then \n\
-        echo \"[ACTION] Creating Traditional bridge: \$br_name\" \n\
-        ip link add dev \"\$br_name\" type bridge || return 1 \n\
-    fi \n\
-    ip link set \"\$br_name\" up \n\
-\n\
-   if ! ip link show \"\$vxlan_interface\" >/dev/null 2>\&1; then \n\
-        ip link add dev \$vxlan_interface type vxlan id \$vlan_id dstport 4789 local \$vlan_local nolearning \n\
-        echo \"[ACTION] Connected VXLAN \$vxlan_interface to \$br_name\" \n\
-    fi \n\
-    ip link set \"\$vxlan_interface\" up \n\
-    echo \"[ACTION] Activated VXLAN interface: \$vxlan_interface (Status: UP)\" \n\
-    ip link set dev \"\$vxlan_interface\" master \"\$br_name\" \n\
-    echo \"[STATUS] Successfully plugged \$vxlan_interface into bridge \$br_name\" \n\
-\n\
-    shift 3 \n\
-    for port in \"\$@\"; do \n\
-        if [ ! -d \"/sys/class/net/\$port\" ]; then  \n\
-            echo \"[WARN] Interface \$port does not exist. Skipping...\"  \n\
-            continue \n\
-        fi \n\
-\n\
-        if ! ip link show \"\$port\" | grep -q \"master \$br_name\"; then \n\
-            ip link set \"\$port\" master \"\$br_name\" \n\
-        fi \n\
-        ip link set \"\$port\" up \n\
-        echo \"[ACTION] Connected Host Port \$port to \$br_name\" \n\
-    done \n\
-\n\
-    echo \"[STATUS] Bridge \$br_name updated done.\" \n\
     return 0 \n\
 } \n\
 \n\
-echo \"[SYSTEM] Ethernat Bridge Configuration Starting...\" \n\
-setup_evpn_bridge br0 10 1.1.1.3 eth0 eth2 eth3 \n\
-echo \"[SYSTEM] Ethernat Bridge Configuration Done.\"\n" > /usr/local/bin/assign-bridge-start
+setup_mac "42:03:03:00:03:00" eth0 && \n\
+setup_mac "42:03:03:00:03:01" eth1 && \n\
+setup_mac "42:03:03:00:03:02" eth2 && \n\
+setup_mac "42:03:03:00:03:03" eth3 \n\
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "MAC Setting Done" || \n\
+    log_error "assign-mac-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-mac-start
+
+RUN chmod +x /usr/local/bin/assign-mac-start
+
+################################################################################
+# STEP: Ethernet Bridge Configuration and Multi-Interface Binding
+#
+# This script creates a software bridge (Layer 2) and binds multiple physical/
+# virtual interfaces to it. It ensures reliable execution through precise state 
+# validation for each member interface.
+#
+# Key Features:
+#  - Idempotent Bridge Checks: Uses native 'ip link' to prevent duplicating bridges.
+#  - Port Sanitization: Validates the existence of each target interface before 
+#    attempting to attach it to the bridge, preventing script crashes.
+################################################################################
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+setup_bridge() { \n\
+    local BR_NAME=$1 \n\
+    shift \n\
+\n\ 
+    log_system "setup_bridge" \n\
+    if ip link show "$BR_NAME" >/dev/null 2>&1; then \n\
+        log_error "$BR_NAME already exists." \n\
+        return 1 \n\
+    fi \n\
+    if ! ip link add "$BR_NAME" type bridge; then \n\
+        log_error "Bridge $BR_NAME not created" && return 2 \n\
+    fi \n\
+    log_status "Created $BR_NAME brige" \n\
+    if ! ip link set dev "$BR_NAME" up; then \n\
+        log_error "$BR_NAME set up fail" && return 2 \n\
+    fi \n\
+    for interface in "$@"; do \n\
+        if ! ip link show "$interface" >/dev/null 2>&1 ; then \n\
+            log_warning "$interface not founded." && continue \n\
+        fi \n\
+        if ! ip link set dev "$interface" master "$BR_NAME"; then \n\
+            log_warning "Failed to set master $interface for $BR_NAME" && continue \n\
+        fi \n\
+    done \n\
+    log_success "Setup bridge $BR_NAME $@" \n\
+    return 0 \n\
+} \n\
+setup_bridge br0 eth0 eth2 eth3 \n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "Bridge Setting Done" || \n\
+    log_error "docker-bridge-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-bridge-start
 
 RUN chmod +x /usr/local/bin/assign-bridge-start
 
 ################################################################################
-# STEP: DHCP Service Initialization
+# STEP: VXLAN Overlay Network and Bridge Binding Configuration
 #
-# This script ensures the persistence of the DHCP lease database and launches
-# the udhcpd daemon on the pre-configured br0 interface.
+# This script establishes a high-performance VXLAN overlay tunnel (Layer 2 over 
+# Layer 3) and integrates it into a local software bridge (br0). It enables 
+# seamless, cross-host container communication across distinct physical nodes.
 #
-# Execution Flow:
-#  1. Environment Preparation: Validates and creates required directories 
-#     for the DHCP lease database.
-#  2. Service Initialization: Launches the udhcpd daemon in the background 
-#     ensuring non-blocking operation.
+# Key Features:
+#  - Idempotent VXLAN Provisioning: Avoids interface duplication by validating 
+#    pre-existing tunnel endpoints with native 'ip link' checks.
+#  - Network Optimization & Acceleration: Explicitly configures UDP checksums 
+#    (udpcsum) and disables IPv6 zero checksum constraints (noudp6zerocsumtx/rx) 
+#    to drastically reduce encapsulation overhead and boost throughput.
+#  - Robust Multi-Component Validation: Ensures that both physical interfaces and 
+#    target software bridges exist and are healthy before committing tunnel attachments.
 ################################################################################
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+setup_vxlan_leaf() { \n\
+    local VTEP_LOCAL_IP=$1 \n\
+    local VNI=$2 \n\
+    local VXLAN_NAME="vxlan$VNI" \n\
+\n\
+    log_system "setup_vxlan" \n\
+    if ! ip -4 addr show dev lo | grep -F -w "$VTEP_LOCAL_IP" >/dev/null 2>&1; then \n\
+        log_warning "Loopback Interface $VTEP_LOCAL_IP not founded" \n\
+    fi \n\
+    if ip link show "$VXLAN_NAME" >/dev/null 2>&1; then \n\
+        log_error "VXLAN $VXLAN_NAME already exists." && return 2 \n\
+    fi \n\
+    if ! ip link add dev "$VXLAN_NAME" type vxlan \
+    id "$VNI" \
+    dstport 4789 \
+    local "$VTEP_LOCAL_IP" \
+    nolearning \
+    udpcsum noudp6zerocsumtx noudp6zerocsumrx ; then \n\
+        log_error "VXLAN $VXLAN_NAME Created fail" && return 2 \n\
+    fi \n\
+    log_status "Created vxlan $VXLAN_NAME" \n\
+    if ! ip link set dev "$VXLAN_NAME" up; then \n\
+        log_error "$VXLAN_NAME set up fail" && return 2 \n\
+    fi \n\
+    log_success "Setup VXLAN $VXLAN_NAME" \n\
+    return 0 \n\
+} \n\
+setup_vxlan_bridge() { \n\
+    local VXLAN_NAME=$1 \n\
+    local BR_NAME=$2 \n\
+\n\
+    log_system "setup_vxlan_bridge" \n\
+    if ! ip link show "$VXLAN_NAME" >/dev/null 2>&1; then \n\
+        log_error "VXLAN $VXLAN_NAME not founded" && return 2 \n\
+    fi \n\
+    if ! ip link show "$BR_NAME" >/dev/null 2>&1; then \n\
+        log_error "Bridge $BR_NAME not founded" && return 2 \n\
+    fi \n\
+    if ! ip link set dev "$VXLAN_NAME" master "$BR_NAME"; then \n\
+        log_error "Failed to set master $BR_NAME for $VXLAN_NAME"&& return 2  \n\
+    fi \n\
+    log_success "Setup VXLAN bridge connected $VXLAN_NAME to $BR_NAME" \n\
+    return 0 \n\
+} \n\
+\n\
+setup_vxlan_leaf 1.1.1.3 10 && \n\
+setup_vxlan_bridge vxlan10 br0 \n\
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "VXLAN Setting Done" || \n\
+    log_error "assign-vxlan-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-vxlan-start
 
-RUN sed -i -r 's/^#*[[:space:]]*start[[:space:]]+.*/start           20.1.1.2/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*end[[:space:]]+.*/end             20.1.1.254/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*interface[[:space:]]+.*/interface       br0/' /etc/udhcpd.conf && \
-    sed -i '/^opt/s/^/#/' /etc/udhcpd.conf && \
-    sed -i '/^option/s/^/#/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*opt[[:space:]]+dns[[:space:]]+[0-9.]+.*/opt     dns     8.8.8.8/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*option[[:space:]]+subnet[[:space:]]+[0-9.]+.*/option  subnet  255.255.255.0/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*opt[[:space:]]+router[[:space:]]+[0-9.]+.*/opt     router  20.1.1.1/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*auto_time[[:space:]]+.*/auto_time 60/' /etc/udhcpd.conf && \
-    sed -i 's/^#*lease_file.*/lease_file \/var\/lib\/misc\/udhcpd.leases/' /etc/udhcpd.conf
-
-RUN touch /var/lib/misc/udhcpd.leases
-
-RUN printf "#!/bin/sh\n\
-udhcpd -f /etc/udhcpd.conf > /var/log/udhcpd.log 2>&1 &\n\
-sleep 1\n\
-if pgrep udhcpd > /dev/null; then\n\
-    echo '[SUCCESS] udhcpd is running.'\n\
-else\n\
-    echo '[ERROR] udhcpd failed to start. Check /var/log/udhcpd.log'\n\
-fi\n\
-" > /usr/local/bin/assign-udhc-start
-
-RUN chmod +x /usr/local/bin/assign-udhc-start
+RUN chmod +x /usr/local/bin/assign-vxlan-start
 
 ################################################################################
 # STEP: Ethernet & VXLAN Infrastructure Orchestration
@@ -328,13 +347,22 @@ RUN chmod +x /usr/local/bin/assign-udhc-start
 #  2. VXLAN Tunneling: Establishes remote L2-over-L3 connectivity.
 #  3. Final Validation: Signals the completion of the network stack.
 ################################################################################
-RUN printf "#!/bin/sh\n\
-/usr/local/bin/assign-mac-start \n\
-/usr/local/bin/assign-bridge-start \n\
-# /usr/local/bin/assign-udhc-start \n\
-echo \"Docker Ethernat Setting Done\n\"\n" > /usr/local/bin/docker-ethernat-start
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+/usr/local/bin/assign-mac-start && \n\
+/usr/local/bin/assign-bridge-start && \n\
+/usr/local/bin/assign-vxlan-start \n\
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "Docker Ethernat Setting Done" || \n\
+    log_error "docker-ethernet-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/docker-ethernet-start
 
-RUN chmod +x /usr/local/bin/docker-ethernat-start
+RUN chmod +x /usr/local/bin/docker-ethernet-start
 
 ################################################################################
 # STEP: Master System Entrypoint & Service Orchestration
@@ -344,7 +372,7 @@ RUN chmod +x /usr/local/bin/docker-ethernat-start
 # architectural integrity:
 #
 # Sequence:
-#  1. Infrastructure Layer: Invokes 'docker-ethernat-start' to configure 
+#  1. Infrastructure Layer: Invokes 'docker-ethernet-start' to configure 
 #     local bridges and VXLAN tunnels.
 #  2. Routing Layer: Invokes 'setup-frr-daemons' to launch the core routing 
 #     stack (Zebra, BGP, etc.) once the network substrate is ready.
@@ -354,11 +382,12 @@ RUN chmod +x /usr/local/bin/docker-ethernat-start
 # Design Note: Includes a 'tail -f /dev/null' safety lock to prevent 
 # unexpected container termination.
 ################################################################################
-RUN printf "#!/bin/sh\n\
-/usr/local/bin/docker-ethernat-start \n\
+RUN printf '#!/bin/sh \n\
+/usr/local/bin/docker-ethernet-start && \n\
 /usr/local/bin/setup-frr-daemons \n\
 while true; do /bin/busybox sh ; done \n\
-tail -f /dev/null\n" > /usr/lib/frr/docker-start
+tail -f /dev/null \n\
+' > /usr/lib/frr/docker-start
 
 RUN chmod +x /usr/lib/frr/docker-start
 

--- a/p3/kyoulee-3-host
+++ b/p3/kyoulee-3-host
@@ -1,10 +1,17 @@
+################################################################################
+# STEP: Base Image Selection & Core Network Packages Installation
+#
+# This layer builds the baseline execution environment for the routing container:
+#  - Uses Alpine Linux 3.19 as a verified, secure, and lightweight footprint.
+#  - Installs BusyBox utilities to provide essential CLI debugging tools.
+################################################################################
 FROM alpine:3.19
 
 RUN apk update && apk add --no-cache \
     busybox \
     busybox-extras \
-    tini
-
+    tini \
+    tcpdump
 ################################################################################
 # STEP: Common Utility Library Initialization
 #
@@ -16,24 +23,30 @@ RUN apk update && apk add --no-cache \
 #   . /usr/local/bin/common-lib.sh
 #   log_status <command> <args>
 ################################################################################
-RUN printf "#!/bin/sh\n\
-log_msg() {\n\
-    local tag=\$1\n\
+RUN printf '#!/bin/sh \n\
+log_msg() { \n\
+    local tag=$1 \n\
 \n\
-    if [ \$# -lt 2 ]; then\n\
-        echo \"[FATAL] Wrong usage of log_msg!\"\n\
-        echo \"[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]\"\n\
-        return 1\n\
-    fi\n\
-    shift\n\
-    \"\$@\" 2>&1 | sed \"s/^/[\$tag] /\"\n\
-}\n\
+    if [ $# -lt 2 ]; then \n\
+        echo "[FATAL] Wrong usage of log_msg!" \n\
+        echo "[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]" \n\
+        return 1 \n\
+    fi \n\
+    shift \n\
+    echo "$@" 2>&1 | sed "s/^/[$tag] /" \n\
+} \n\
 \n\
-log_status() { log_msg \"STATUS\" \"\$@\"; }\n\
-log_init()   { log_msg \"INIT\" \"\$@\"; }\n\
-log_fatal()   { log_msg \"FATAL\" \"\$@\"; }\n\
-log_error()  { log_msg \"ERROR\" \"\$@\"; }\n" > /usr/local/bin/common-lib.sh && \
-chmod +x /usr/local/bin/common-lib.sh
+log_status() { log_msg "STATUS" "$@"; } \n\
+log_init()   { log_msg "INIT" "$@"; } \n\
+log_system() { log_msg "SYSTEM" "$@"; } \n\
+log_action() { log_msg "ACTION" "$@"; } \n\
+log_success(){ log_msg "SUCCESS" "$@"; } \n\
+log_fatal()  { log_msg "FATAL" "$@"; } \n\
+log_error()  { log_msg "ERROR" "$@"; } \n\
+log_warning(){ log_msg "WARNING" "$@"; } \n\
+' > /usr/local/bin/common-lib.sh
+
+RUN chmod +x /usr/local/bin/common-lib.sh
 
 ################################################################################
 # STEP: MAC Address Configuration Utility
@@ -42,182 +55,123 @@ chmod +x /usr/local/bin/common-lib.sh
 # interfaces. It ensures the interface state is managed correctly during 
 # the transition and verifies the hardware presence before execution.
 ################################################################################
-RUN printf "#!/bin/sh \n\
-. /usr/local/bin/common-lib.sh\n\
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+setup_mac() { \n\
+    local MAC_ADDR=$1 \n\
+    local INTERFACE=$2 \n\
 \n\
-set_mac() { \n\
-    local mac=\$1 \n\
-    local dev=\$2 \n\
-\n\
-    if [ -z \"\$mac\" ] || [ -z \"\$dev\" ]; then \n\
-        echo \"[FATAL] Missing arguments! Usage: set_mac <mac_address> <device_name>\" \n\
-        return 1 \n\
+    log_system "setup_mac" \n\
+    if [ ! -d "/sys/class/net/$INTERFACE" ]; then \n\
+        log_warning "Interface $INTERFACE not found." && return 0 \n\
     fi \n\
-\n\
-    if [ ! -d \"/sys/class/net/\$dev\" ]; then \n\
-        echo \"[FATAL] Interface \$dev not found.\" \n\
-        return 1 \n\
+    if ! ip link set "$INTERFACE" down ; then \n\
+        log_error "Interface $INTERFACE can not setup downlink" && return 0 \n\
     fi \n\
-\n\
-    local current_mac=\$(cat /sys/class/net/\$dev/address) \n\
-    if [ \"\$current_mac\" = \"\$mac\" ]; then \n\
-        echo \"[SKIP] \$dev already has MAC \$mac.\" \n\
-    else \n\
-        echo \"[ACTION] Changing \$dev MAC from \$current_mac to \$mac...\" \n\
-        ip link set \"\$dev\" down \n\
-        if ip link set \"\$dev\" address \"\$mac\"; then \n\
-            ip link set \"\$dev\" up \n\
-            echo \"[SUCCESS] MAC address updated for \$dev.\" \n\
-        else \n\
-            echo \"[ERROR] Failed to set MAC for \$dev. (Check permissions/validity)\" \n\
-            ip link set \"\$dev\" up \n\
-            return 1 \n\
-        fi \n\
+    if ! ip link set "$INTERFACE" address "$MAC_ADDR"; then \n\
+        log_warning "Interface $INTERFACE setting MAC address failed" && return 0 \n\
     fi \n\
+    if ! ip link set "$INTERFACE" up ; then \n\
+        log_error "Interface $INTERFACE can not setup uplink" && return 1 \n\
+    fi \n\
+    return 0 \n\
 } \n\
 \n\
-set_mac \"42:03:00:01:03:00\" \"eth0\" \n\
-" > /usr/local/bin/assign-mac-start
+setup_mac "42:03:01:00:03:00" eth0 \n\
+setup_mac "42:03:01:00:03:01" eth1 \n\
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "MAC Setting Done" || \n\
+    log_error "assign-mac-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-mac-start
 
 RUN chmod +x /usr/local/bin/assign-mac-start
+
 ################################################################################
 # STEP: Network Interface Configuration
 #
 # Automates the setup of IP addresses and routing tables.
-# Uses idempotent functions (set_ip, set_gateway) to prevent redundant
+# Uses idempotent functions (setup_interface_ip) to prevent redundant
 # configurations and ensure the system state remains consistent.
 ################################################################################
-RUN printf "#!/bin/sh \n\
+RUN printf '#!/bin/sh \n\
 . /usr/local/bin/common-lib.sh\n\
 \n\
-set_ip() { \n\
-    local ip=\$1 \n\
-    local dev=\$2 \n\
-    local target_ip=\${ip%%/*} \n\
+setup_interface_ip() { \n\
+    local LOOPBACK_IP=$1 \n\
+    local INTERFACE=$2 \n\
 \n\
-    if [ -z \"\$ip\" ] || [ -z \"\$dev\" ]; then \n\
-        echo \"[FATAL] Missing arguments! Usage: set_ip <ip/mask> <device_name>\" \n\
-        return 1 \n\
+    log_system "setup_interface_ip" \n\
+    if ! ip link show "$INTERFACE" >/dev/null 2>&1; then \n\
+        log_error "Interface $INTERFACE not found" && return 2 \n\
     fi \n\
-    if [ ! -d \"/sys/class/net/\$dev\" ]; then \n\
-        echo \"[FATAL] Interface \$dev not found.\" \n\
-        return 1 \n\
+    if ip addr show dev "$INTERFACE" | grep -Fq "$LOOPBACK_IP"; then \n\
+        log_warning "IP $LOOPBACK_IP is already assigned to $INTERFACE." && return 0 \n\ \n\
     fi \n\
-    local current_ipv4=\$(ip -4 -o addr show \"\$dev\" | awk '{print \$4}') \n\
-    if [ -z \"\$current_ipv4\" ]; then \n\
-        echo \"[ACTION] \$dev is clean. Assigning \$ip...\" \n\
-        ip addr add \"\$ip\" dev \"\$dev\" && ip link set \"\$dev\" up \n\
-    elif echo \"\$current_ipv4\" | grep -q \"\$target_ip\"; then \n\
-        echo \"[SKIP] \$dev already has the target IP \$target_ip.\" \n\
-        ip link set \"\$dev\" up \n\
-    else \n\
-        echo \"[FATAL] \$dev has CONFLICTING config: \$current_ipv4\" \n\
-        echo \"[FATAL] Automatic flush is disabled for safety. Manual check required.\" \n\
-        return 1 \n\
+    if ! ip addr add "$LOOPBACK_IP" dev "$INTERFACE"; then \n\
+        log_error "Failed to add IP $LOOPBACK_IP to $INTERFACE" && return 2 \n\
     fi \n\
+    ip link set "$INTERFACE" up \n\
+    log_success "Successfully assigned $LOOPBACK_IP to $INTERFACE" \n\
+    return 0 \n\
 } \n\
+setup_interface_ip 20.1.1.3/24 eth0 \n\
 \n\
-set_gateway() { \n\
-    local gw=\$1 \n\
-\n\    
-    if [ -z \"\$gw\" ]; then \n\
-        echo \"[FATAL] Missing arguments! Usage: set_gateway <gateway_ip>\" \n\
-        return 1 \n\
-    fi \n\
-    local current_gw=\$(ip route show default | awk '/default via/ {print \$3}') \n\
-    if [ \"\$current_gw\" = \"\$gw\" ]; then \n\
-        echo \"[SKIP] Default gateway is already set to \$gw.\" \n\
-    elif [ -z \"\$current_gw\" ]; then \n\
-        echo \"[ACTION] No default gateway found. Setting to \$gw...\" \n\
-        if ip route add default via \"\$gw\"; then \n\
-            echo \"[SUCCESS] Default gateway is now \$gw\" \n\
-        else \n\
-            echo \"[ERROR] Failed to set gateway \$gw. (Check reachability)\" \n\
-            return 1 \n\
-        fi \n\
-    else \n\
-        echo \"[FATAL] Default gateway CONFLICT: Current is \$current_gw, Target is \$gw\" \n\
-        echo \"[FATAL] Automatic override is disabled for safety. Manual intervention required.\" \n\
-        return 1 \n\
-    fi \n\
-} \n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "Interface IP Setting Done" || \n\
+    log_error "docker-ip-start error" \n\
 \n\
-echo \"[SYSTEM] Initializing Network Configuration...\"\n\
-set_ip \"20.1.1.3/24\" \"eth0\" || return 1\n\
-# set_gateway \"20.1.1.254\" || return 1\n\
-echo \"[STATUS] Verification:\"\n\
-log_status ip -4 -o addr show eth1 || echo \"[ERROR] eth1 IPv4 verification failed\"\n\
-# ip route | grep default || echo \"[ERROR] Gateway verification failed\"\n\
-echo \"[SUCCESS] All network configurations applied.\"\n" > /usr/local/bin/assign-ip-start
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-ip-start
 
 RUN chmod +x /usr/local/bin/assign-ip-start
 
 ################################################################################
-# STEP: DHCP Service Initialization
+# STEP: Network Orchestration Entrypoint
 #
-# This script provides a modular and idempotent mechanism to enable DHCP for 
-# specified network interfaces. It abstracts the configuration logic by 
-# parsing and activating entries within '/etc/network/interfaces'.
-#
-# Key Features:
-#  1. Dynamic Interface Targeting: Uses a functional approach to configure 
-#     arbitrary interfaces (e.g., eth0, br0).
-#  2. Fail-Fast Integrity Check: Validates the existence of the configuration 
-#     file and target interface before applying changes.
-#  3. Standardized Logging: Integrates with 'common-lib.sh' to provide 
-#     consistent observability across the network setup process.
+# This script acts as a secondary entrypoint to orchestrate multiple network
+# setup scripts (e.g., assign-ip-start). It ensures that all Ethernet-related
+# configurations are executed in the correct sequence before the main process.
 #
 # Usage:
-#   setup_dhcp_interface <interface_name>
+#   Called internally by /usr/local/bin/docker-start
 ################################################################################
-RUN printf "#!/bin/sh \n\
-sed -i -r 's/^#*[[:space:]]*auto_time[[:space:]]+.*/auto_time 60/' /etc/network/interfaces && \
-" > /usr/local/bin/assign-udhc-start
-
-RUN chmod +x /usr/local/bin/assign-udhc-start
-
-################################################################################
-# STEP: Ethernet & VXLAN Infrastructure Orchestration
-#
-# This script orchestrates the sequential setup of network infrastructure layers.
-# It ensures that local bridging (Layer 2) is established before initializing 
-# VXLAN tunneling (Overlay), following a strictly ordered initialization pattern.
-#
-# Execution Flow:
-#  1. Local Bridge Setup: Configures br0 and binds physical/virtual interfaces.
-#  2. VXLAN Tunneling: Establishes remote L2-over-L3 connectivity.
-#  3. Final Validation: Signals the completion of the network stack.
-################################################################################
-RUN printf "#!/bin/sh\n\
+RUN printf '#!/bin/sh\n\
+. /usr/local/bin/common-lib.sh \n\
 /usr/local/bin/assign-mac-start \n\
 /usr/local/bin/assign-ip-start \n\
-/usr/local/bin/assign-udhc-start \n\
-echo \"Docker Ethernat Setting Done\n\"\n" > /usr/local/bin/docker-ethernat-start
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "Docker Ethernat Setting Done" || \n\
+    log_error "docker-ethernet-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/docker-ethernet-start
 
-RUN chmod +x /usr/local/bin/docker-ethernat-start
+RUN chmod +x /usr/local/bin/docker-ethernet-start
 
 ################################################################################
-# STEP: Master System Entrypoint & Service Orchestration
+# STEP: Main Container Entrypoint
 #
-# This script serves as the primary PID 1 process (or its proxy) for the 
-# container. It follows a strictly ordered initialization sequence to ensure 
-# architectural integrity:
-#
-# Sequence:
-#  1. Infrastructure Layer: Invokes 'docker-ethernat-start' to configure 
-#     local bridges and VXLAN tunnels.
-#  2. Routing Layer: Invokes 'setup-frr-daemons' to launch the core routing 
-#     stack (Zebra, BGP, etc.) once the network substrate is ready.
-#  3. Interaction Layer: Spawns an infinite busybox shell loop for 
-#     administrative access and container persistence.
-#
-# Design Note: Includes a 'tail -f /dev/null' safety lock to prevent 
-# unexpected container termination.
+# This script serves as the final entrypoint for the container. It orchestrates
+# the network initialization sequence and ensures the container remains active.
+# 
+# The design follows the "Keep-Alive" pattern:
+#  1. Executes the network orchestration script.
+#  2. Enters an infinite loop to provide an interactive shell environment.
+#  3. Falls back to 'tail -f' to prevent container exit if the shell terminates.
 ################################################################################
-RUN printf "#!/bin/sh\n\
-/usr/local/bin/docker-ethernat-start \n\
+RUN printf '#!/bin/sh \n\
+/usr/local/bin/docker-ethernet-start \n\
 while true; do /bin/busybox sh ; done \n\
-tail -f /dev/null\n" > /usr/local/bin/docker-start
+tail -f /dev/null \n\
+' > /usr/local/bin/docker-start
 
 RUN chmod +x /usr/local/bin/docker-start
 

--- a/p3/kyoulee-4
+++ b/p3/kyoulee-4
@@ -1,10 +1,21 @@
+################################################################################
+# STEP: Base Image Selection & Core Network Packages Installation
+#
+# This layer builds the baseline execution environment for the routing container:
+#  - Uses Alpine Linux 3.19 as a verified, secure, and lightweight footprint.
+#  - Installs FRR (Free Range Routing) for enterprise-grade routing protocols.
+#  - Installs BusyBox utilities to provide essential CLI debugging tools.
+#  - Integrates 'tini' as a minimal init system to safely manage zombie processes
+#    and properly forward OS signals within the container lifecycle.
+################################################################################
 FROM alpine:3.19
 
 RUN apk update && apk add --no-cache \
     frr \
     busybox \
     busybox-extras \
-    tini
+    tini \
+    tcpdump
 
 ################################################################################
 # STEP: Common Utility Library Initialization
@@ -17,45 +28,74 @@ RUN apk update && apk add --no-cache \
 #   . /usr/local/bin/common-lib.sh
 #   log_status <command> <args>
 ################################################################################
-RUN printf "#!/bin/sh\n\
-log_msg() {\n\
-    local tag=\$1\n\
+RUN printf '#!/bin/sh \n\
+log_msg() { \n\
+    local tag=$1 \n\
 \n\
-    if [ \$# -lt 2 ]; then\n\
-        echo \"[FATAL] Wrong usage of log_msg!\"\n\
-        echo \"[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]\"\n\
-        return 1\n\
-    fi\n\
-    shift\n\
-    \"\$@\" 2>&1 | sed \"s/^/[\$tag] /\"\n\
-}\n\
+    if [ $# -lt 2 ]; then \n\
+        echo "[FATAL] Wrong usage of log_msg!" \n\
+        echo "[USAGE] log_msg <TAG> <COMMAND> [ARGUMENTS...]" \n\
+        return 1 \n\
+    fi \n\
+    shift \n\
+    echo "$@" 2>&1 | sed "s/^/[$tag] /" \n\
+} \n\
 \n\
-log_status() { log_msg \"STATUS\" \"\$@\"; }\n\
-log_init()   { log_msg \"INIT\" \"\$@\"; }\n\
-log_fatal()   { log_msg \"FATAL\" \"\$@\"; }\n\
-log_error()  { log_msg \"ERROR\" \"\$@\"; }\n" > /usr/local/bin/common-lib.sh && \
-chmod +x /usr/local/bin/common-lib.sh
+log_status() { log_msg "STATUS" "$@"; } \n\
+log_init()   { log_msg "INIT" "$@"; } \n\
+log_system() { log_msg "SYSTEM" "$@"; } \n\
+log_action() { log_msg "ACTION" "$@"; } \n\
+log_success(){ log_msg "SUCCESS" "$@"; } \n\
+log_fatal()  { log_msg "FATAL" "$@"; } \n\
+log_error()  { log_msg "ERROR" "$@"; } \n\
+log_warning(){ log_msg "WARNING" "$@"; } \n\
+' > /usr/local/bin/common-lib.sh
+
+RUN chmod +x /usr/local/bin/common-lib.sh
 
 ################################################################################
-# STEP: FRR (Free Range Routing) Service Initialization
+# STEP: FRR Daemon Activation & Configuration Initialization
 #
-# Enables specific routing protocol daemons (Zebra, BGP, OSPF) by 
-# modifying the service configuration. Zebra acts as the central manager 
-# for the underlying kernel routing table.
-#
+# This step pre-configures the FRR environment prior to the service launch:
+#  1. Modifies '/etc/frr/daemons' to explicitly enable routing protocols 
+#     (Zebra, BGP, OSPF, IS-IS) and disables the 'watchfrr' supervisor 
+#     to hand over execution control to the container entrypoint.
+#  2. Generates baseline configuration stub files required by the FRR 
+#     daemons to prevent initialization failures during boot.
 ################################################################################
 RUN sed -i 's/zebra=no/zebra=yes/' /etc/frr/daemons && \
     sed -i 's/bgpd=no/bgpd=yes/' /etc/frr/daemons && \
-    sed -i 's/ospfd=no/ospfd=yes/' /etc/frr/daemons
+    sed -i 's/ospfd=no/ospfd=yes/' /etc/frr/daemons && \
+    sed -i 's/isisd=no/isisd=yes/' /etc/frr/daemons && \
+    sed -i 's/watchfrr_options=.*$/watchfrr_options=""/' /etc/frr/daemons
 
-RUN printf "\n\
+################################################################################
+# STEP: Leaf/Access Node Routing & VTEP Control Plane Configuration (FRR)
+#
+# Configures FRRouting (FRR) to act as an EVPN Leaf (VTEP) switch connected to
+# the Spine Route Reflector (1.1.1.1) over an OSPF Area 0 underlay network.
+# This establishing the local tunnel endpoint for VXLAN encapsulation.
+#
+# 1. Interfaces & Underlay (OSPF):
+#    - Provisions 'lo' (1.1.1.4/32) as the immutable VTEP source / Router ID.
+#    - Sets up point-to-point link (eth0) to upstream Spine switch.
+#    - Advertises 'lo' and 'eth0' into OSPF Area 0 for infrastructure reachability.
+#
+# 2. Control Plane (iBGP EVPN Client):
+#    - Establishes an iBGP session under AS 1 peering directly with the Spine/RR.
+#    - Uses the persistent 'lo' interface as the BGP session update-source.
+#    - Activates EVPN address-family to receive/send network reachability.
+#    - Enables 'advertise-all-vni' to automatically export all local VXLAN VNI 
+#      mappings (e.g., VNI 10) to the Route Reflector.
+################################################################################
+RUN printf '\n\
 frr version 9.1 \n\
 frr default traditional \n\
-hostname kyoulee-2 \n\
+hostname kyoulee-4 \n\
 log syslog informational \n\
-" > /etc/frr/frr.conf
+' > /etc/frr/frr.conf
 
-RUN printf "\n\
+RUN printf '\n\
 ! \n\
 interface lo \n\
   ip address 1.1.1.4/32 \n\
@@ -66,13 +106,13 @@ interface eth2 \n\
   no shutdown \n\
 exit \n\
 ! \n\
-" >> /etc/frr/frr.conf
+' >> /etc/frr/frr.conf
 
-RUN printf "\n\
+RUN printf '\n\
 ! \n\
-router bgp 65001 \n\
+router bgp 1 \n\
   bgp router-id 1.1.1.4 \n\
-  neighbor 1.1.1.1 remote-as 65001 \n\
+  neighbor 1.1.1.1 remote-as 1 \n\
   neighbor 1.1.1.1 update-source lo \n\
   address-family ipv4 unicast \n\
     neighbor 1.1.1.1 activate \n\
@@ -83,9 +123,9 @@ router bgp 65001 \n\
   exit-address-family \n\
 exit \n\
 ! \n\
-" >> /etc/frr/frr.conf
+' >> /etc/frr/frr.conf
 
-RUN printf "\n\
+RUN printf '\n\
 ! \n\
 router ospf \n\
   ospf router-id 1.1.1.4 \n\
@@ -97,7 +137,7 @@ interface eth2 \n\
   ip ospf area 0 \n\
 exit \n\
 ! \n\
-" >> /etc/frr/frr.conf
+' >> /etc/frr/frr.conf
 
 RUN chown frr:frr /etc/frr/frr.conf && \
     chmod 640 /etc/frr/frr.conf
@@ -109,14 +149,14 @@ RUN chown frr:frr /etc/frr/frr.conf && \
 # Separating this from the main entrypoint allows for cleaner service 
 # management and independent troubleshooting of the routing stack.
 ################################################################################
-RUN printf "#!/bin/sh\n\
+RUN printf '#!/bin/sh\n\
+. /usr/local/bin/common-lib.sh\n\
 \n\
-echo \"[SYSTEM]Launching FRR Routing Stack...\"\n\
+log_system "Launching FRR Routing Stack..." \n\
 /usr/lib/frr/frrinit.sh start \n\
 /usr/lib/frr/frrinit.sh status \n\
-# vtysh -c \"copy running-config startup-config\" \n\
-# vtysh -c \"show running-config\" \n\
-echo \"[SUCCESS]All FRR daemons are now running in the background.\"\n" > /usr/local/bin/setup-frr-daemons
+log_success "All FRR daemons are now running in the background." \n\
+' > /usr/local/bin/setup-frr-daemons
 
 RUN chmod +x /usr/local/bin/setup-frr-daemons
 
@@ -127,196 +167,173 @@ RUN chmod +x /usr/local/bin/setup-frr-daemons
 # interfaces. It ensures the interface state is managed correctly during 
 # the transition and verifies the hardware presence before execution.
 ################################################################################
-RUN printf "#!/bin/sh \n\
-. /usr/local/bin/common-lib.sh\n\
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+setup_mac() { \n\
+    local MAC_ADDR=$1 \n\
+    local INTERFACE=$2 \n\
 \n\
-set_mac() { \n\
-    local mac=\$1 \n\
-    local dev=\$2 \n\
-\n\
-    if [ -z \"\$mac\" ] || [ -z \"\$dev\" ]; then \n\
-        echo \"[FATAL] Missing arguments! Usage: set_mac <mac_address> <device_name>\" \n\
-        return 1 \n\
+    log_system "setup_mac" \n\
+    if [ ! -d "/sys/class/net/$INTERFACE" ]; then \n\
+        log_warning "Interface $INTERFACE not found." && return 0 \n\
     fi \n\
-\n\
-    if [ ! -d \"/sys/class/net/\$dev\" ]; then \n\
-        echo \"[FATAL] Interface \$dev not found.\" \n\
-        return 1 \n\
+    if ! ip link set "$INTERFACE" down ; then \n\
+        log_error "Interface $INTERFACE can not setup downlink" && return 0 \n\
     fi \n\
-\n\
-    local current_mac=\$(cat /sys/class/net/\$dev/address) \n\
-    if [ \"\$current_mac\" = \"\$mac\" ]; then \n\
-        echo \"[SKIP] \$dev already has MAC \$mac.\" \n\
-    else \n\
-        echo \"[ACTION] Changing \$dev MAC from \$current_mac to \$mac...\" \n\
-        ip link set \"\$dev\" down \n\
-        if ip link set \"\$dev\" address \"\$mac\"; then \n\
-            ip link set \"\$dev\" up \n\
-            echo \"[SUCCESS] MAC address updated for \$dev.\" \n\
-        else \n\
-            echo \"[ERROR] Failed to set MAC for \$dev. (Check permissions/validity)\" \n\
-            ip link set \"\$dev\" up \n\
-            return 1 \n\
-        fi \n\
+    if ! ip link set "$INTERFACE" address "$MAC_ADDR"; then \n\
+        log_warning "Interface $INTERFACE setting MAC address failed" && return 0 \n\
     fi \n\
+    if ! ip link set "$INTERFACE" up ; then \n\
+        log_error "Interface $INTERFACE can not setup uplink" && return 1 \n\
+    fi \n\
+    return 0 \n\
 } \n\
 \n\
-set_mac \"42:03:04:00:03:00\" \"eth0\" \n\
-set_mac \"42:03:04:00:03:01\" \"eth1\" \n\
-set_mac \"42:03:04:00:03:02\" \"eth2\" \n\
-set_mac \"42:03:04:00:03:03\" \"eth3\" \n" > /usr/local/bin/assign-mac-start
+setup_mac "42:03:03:00:04:00" eth0 && \n\
+setup_mac "42:03:03:00:04:01" eth1 && \n\
+setup_mac "42:03:03:00:04:02" eth2 && \n\
+setup_mac "42:03:03:00:04:03" eth3 \n\
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "MAC Setting Done" || \n\
+    log_error "assign-mac-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-mac-start
 
 RUN chmod +x /usr/local/bin/assign-mac-start
 
 ################################################################################
-# STEP: Ethernet Bridge Configuration with Multi-Port Binding
+# STEP: Ethernet Bridge Configuration and Multi-Interface Binding
 #
-# This script orchestrates the creation of a software bridge (Layer 2) and 
-# assigns an IP address (Layer 3) to the bridge interface. It enables 
-# multi-port binding while ensuring strict state validation for each member 
-# interface.
+# This script creates a software bridge (Layer 2) and binds multiple physical/
+# virtual interfaces to it. It ensures reliable execution through precise state 
+# validation for each member interface.
 #
 # Key Features:
-#  - Idempotent Bridge Creation: Uses 'brctl' to verify or create bridge instances.
-#  - IP Conflict Guard: Aborts if the bridge already carries a conflicting IP.
-#  - Port Sanitization: Skips ports that do not exist or have existing L3 configs
-#    to prevent breaking network isolation in GNS3/VXLAn environments.
-#  - Detailed Verification: Outputs the final spanning tree/port status.
+#  - Idempotent Bridge Checks: Uses native 'ip link' to prevent duplicating bridges.
+#  - Port Sanitization: Validates the existence of each target interface before 
+#    attempting to attach it to the bridge, preventing script crashes.
 ################################################################################
-RUN printf "#!/bin/sh\n\
-. /usr/local/bin/common-lib.sh\n\
-\n\
-setup_bridge_with_ip_ports () {\n\
-    local br_name=\$1\n\
-    local br_ip_with_mask=\$2\n\
-    local target_ip=\${br_ip_with_mask%%/*}\n\
-    if [ -z \"\$br_name\" ] || [ -z \"\$br_ip_with_mask\" ]; then\n\
-        echo \"[FATAL] Missing arguments! Usage: setup_bridge_with_ip_ports <br_name> <ip/mask> <ports...>\"\n\
-        return 1\n\
-    fi\n\
-    if ! brctl show \"\$br_name\" >/dev/null 2>&1; then\n\
-        brctl addbr \"\$br_name\" || return 1\n\
-    fi\n\
-    ip link set \"\$br_name\" up\n\
-    local current_ipv4=\$(ip -4 -o addr show \"\$br_name\" | awk '{print \$4}')\n\
-    if [ -z \"\$current_ipv4\" ]; then\n\
-        echo \"[ACTION] \$br_name is clean. Assigning \$br_ip_with_mask...\"\n\
-        ip addr add \"\$br_ip_with_mask\" dev \"\$br_name\"\n\
-    elif echo \"\$current_ipv4\" | grep -q \"\$target_ip\"; then\n\
-        echo \"[SKIP] \$br_name already has the target IP \$target_ip.\"\n\
-    else\n\
-        echo \"[FATAL] \$br_name is ALREADY IN USE with: \$current_ipv4\"\n\
-        echo \"[FATAL] Manual intervention required to avoid service disruption.\"\n\
-        return 1\n\
-    fi\n\
-    shift 2\n\
-    for port in \"\$@\"; do\n\
-        if [ ! -d \"/sys/class/net/\$port\" ]; then \n\
-            echo \"[WARN] Interface $port does not exist. Skipping...\" \n\
-            continue; \n\
-        fi \n\
-        if [ -n \"\$(ip -4 -o addr show \"\$port\")\" ]; then \n\
-            echo \"[ERROR] Port \$port has existing config. Skipping to prevent breakage.\" \n\
-            continue; \n\
-        fi \n\
-        if ! brctl show \"\$br_name\" | grep -q \"\$port\"; then \n\
-            brctl addif \"\$br_name\" \"\$port\"\n\
-        fi\n\
-        ip link set \"\$port\" up\n\
-    done\n\
-    echo \"[STATUS] Final Bridge Configuration for: \$br_name\"\n\
-    log_status brctl show \"\$br_name\"\n\
-    log_status ip -4 -o addr show \"\$br_name\"\n\
-    return 0\n\
-}\n\
-\n\
-setup_evpn_bridge() { \n\
-    local br_name=\$1 \n\
-    local vlan_id=\$2 \n\
-    local vlan_local=\$3 \n\
-    local vxlan_interface=\"vxlan\${vlan_id}\" \n\
-\n\
-    if [ -z \"\$br_name\" ] || [ -z \"\$vlan_id\" ] || [ -z \"\$vlan_local\" ]; then \n\
-        echo \"[FATAL] Usage: setup_evpn_bridge <br_name> <vlan_id> <vlan_local> <host_ports...>\" \n\
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+setup_bridge() { \n\
+    local BR_NAME=$1 \n\
+    shift \n\
+\n\ 
+    log_system "setup_bridge" \n\
+    if ip link show "$BR_NAME" >/dev/null 2>&1; then \n\
+        log_error "$BR_NAME already exists." \n\
         return 1 \n\
     fi \n\
-\n\
-    if ! ip link show \"\$br_name\" >/dev/null 2>\&1; then \n\
-        echo \"[ACTION] Creating Traditional bridge: \$br_name\" \n\
-        ip link add dev \"\$br_name\" type bridge || return 1 \n\
+    if ! ip link add "$BR_NAME" type bridge; then \n\
+        log_error "Bridge $BR_NAME not created" && return 2 \n\
     fi \n\
-    ip link set \"\$br_name\" up \n\
-\n\
-   if ! ip link show \"\$vxlan_interface\" >/dev/null 2>\&1; then \n\
-        ip link add dev \$vxlan_interface type vxlan id \$vlan_id dstport 4789 local \$vlan_local nolearning \n\
-        echo \"[ACTION] Connected VXLAN \$vxlan_interface to \$br_name\" \n\
+    log_status "Created $BR_NAME brige" \n\
+    if ! ip link set dev "$BR_NAME" up; then \n\
+        log_error "$BR_NAME set up fail" && return 2 \n\
     fi \n\
-    ip link set \"\$vxlan_interface\" up \n\
-    echo \"[ACTION] Activated VXLAN interface: \$vxlan_interface (Status: UP)\" \n\
-    ip link set dev \"\$vxlan_interface\" master \"\$br_name\" \n\
-    echo \"[STATUS] Successfully plugged \$vxlan_interface into bridge \$br_name\" \n\
-\n\
-    shift 3 \n\
-    for port in \"\$@\"; do \n\
-        if [ ! -d \"/sys/class/net/\$port\" ]; then  \n\
-            echo \"[WARN] Interface \$port does not exist. Skipping...\"  \n\
-            continue \n\
+    for interface in "$@"; do \n\
+        if ! ip link show "$interface" >/dev/null 2>&1 ; then \n\
+            log_warning "$interface not founded." && continue \n\
         fi \n\
-\n\
-        if ! ip link show \"\$port\" | grep -q \"master \$br_name\"; then \n\
-            ip link set \"\$port\" master \"\$br_name\" \n\
+        if ! ip link set dev "$interface" master "$BR_NAME"; then \n\
+            log_warning "Failed to set master $interface for $BR_NAME" && continue \n\
         fi \n\
-        ip link set \"\$port\" up \n\
-        echo \"[ACTION] Connected Host Port \$port to \$br_name\" \n\
     done \n\
-\n\
-    echo \"[STATUS] Bridge \$br_name updated done.\" \n\
+    log_success "Setup bridge $BR_NAME $@" \n\
     return 0 \n\
 } \n\
+setup_bridge br0 eth0 eth1 eth3 \n\
+RETURN_CODE=$? \n\
 \n\
-echo \"[SYSTEM] Ethernat Bridge Configuration Starting...\" \n\
-setup_evpn_bridge br0 10 1.1.1.4 eth0 eth1 eth3 \n\
-echo \"[SYSTEM] Ethernat Bridge Configuration Done.\"\n" > /usr/local/bin/assign-bridge-start
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "Bridge Setting Done" || \n\
+    log_error "docker-bridge-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-bridge-start
 
 RUN chmod +x /usr/local/bin/assign-bridge-start
 
 ################################################################################
-# STEP: DHCP Service Initialization
+# STEP: VXLAN Overlay Network and Bridge Binding Configuration
 #
-# This script ensures the persistence of the DHCP lease database and launches
-# the udhcpd daemon on the pre-configured br0 interface.
+# This script establishes a high-performance VXLAN overlay tunnel (Layer 2 over 
+# Layer 3) and integrates it into a local software bridge (br0). It enables 
+# seamless, cross-host container communication across distinct physical nodes.
 #
-# Execution Flow:
-#  1. Environment Preparation: Validates and creates required directories 
-#     for the DHCP lease database.
-#  2. Service Initialization: Launches the udhcpd daemon in the background 
-#     ensuring non-blocking operation.
+# Key Features:
+#  - Idempotent VXLAN Provisioning: Avoids interface duplication by validating 
+#    pre-existing tunnel endpoints with native 'ip link' checks.
+#  - Network Optimization & Acceleration: Explicitly configures UDP checksums 
+#    (udpcsum) and disables IPv6 zero checksum constraints (noudp6zerocsumtx/rx) 
+#    to drastically reduce encapsulation overhead and boost throughput.
+#  - Robust Multi-Component Validation: Ensures that both physical interfaces and 
+#    target software bridges exist and are healthy before committing tunnel attachments.
 ################################################################################
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+setup_vxlan_leaf() { \n\
+    local VTEP_LOCAL_IP=$1 \n\
+    local VNI=$2 \n\
+    local VXLAN_NAME="vxlan$VNI" \n\
+\n\
+    log_system "setup_vxlan" \n\
+    if ! ip -4 addr show dev lo | grep -F -w "$VTEP_LOCAL_IP" >/dev/null 2>&1; then \n\
+        log_warning "Loopback Interface $VTEP_LOCAL_IP not founded" \n\
+    fi \n\
+    if ip link show "$VXLAN_NAME" >/dev/null 2>&1; then \n\
+        log_error "VXLAN $VXLAN_NAME already exists." && return 2 \n\
+    fi \n\
+    if ! ip link add dev "$VXLAN_NAME" type vxlan \
+    id "$VNI" \
+    dstport 4789 \
+    local "$VTEP_LOCAL_IP" \
+    nolearning \
+    udpcsum noudp6zerocsumtx noudp6zerocsumrx ; then \n\
+        log_error "VXLAN $VXLAN_NAME Created fail" && return 2 \n\
+    fi \n\
+    log_status "Created vxlan $VXLAN_NAME" \n\
+    if ! ip link set dev "$VXLAN_NAME" up; then \n\
+        log_error "$VXLAN_NAME set up fail" && return 2 \n\
+    fi \n\
+    log_success "Setup VXLAN $VXLAN_NAME" \n\
+    return 0 \n\
+} \n\
+setup_vxlan_bridge() { \n\
+    local VXLAN_NAME=$1 \n\
+    local BR_NAME=$2 \n\
+\n\
+    log_system "setup_vxlan_bridge" \n\
+    if ! ip link show "$VXLAN_NAME" >/dev/null 2>&1; then \n\
+        log_error "VXLAN $VXLAN_NAME not founded" && return 2 \n\
+    fi \n\
+    if ! ip link show "$BR_NAME" >/dev/null 2>&1; then \n\
+        log_error "Bridge $BR_NAME not founded" && return 2 \n\
+    fi \n\
+    if ! ip link set dev "$VXLAN_NAME" master "$BR_NAME"; then \n\
+        log_error "Failed to set master $BR_NAME for $VXLAN_NAME"&& return 2  \n\
+    fi \n\
+    log_success "Setup VXLAN bridge connected $VXLAN_NAME to $BR_NAME" \n\
+    return 0 \n\
+} \n\
+\n\
+setup_vxlan_leaf 1.1.1.4 10 && \n\
+setup_vxlan_bridge vxlan10 br0 \n\
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "VXLAN Setting Done" || \n\
+    log_error "assign-vxlan-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/assign-vxlan-start
 
-RUN sed -i -r 's/^#*[[:space:]]*start[[:space:]]+.*/start           20.1.1.1/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*end[[:space:]]+.*/end             20.1.1.254/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*interface[[:space:]]+.*/interface       br0/' /etc/udhcpd.conf && \
-    sed -i '/^opt/s/^/#/' /etc/udhcpd.conf && \
-    sed -i '/^option/s/^/#/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*opt[[:space:]]+dns[[:space:]]+[0-9.]+.*/opt     dns     8.8.8.8/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*option[[:space:]]+subnet[[:space:]]+[0-9.]+.*/option  subnet  255.255.255.0/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*opt[[:space:]]+router[[:space:]]+[0-9.]+.*/opt     router  20.1.1.1/' /etc/udhcpd.conf && \
-    sed -i -r 's/^#*[[:space:]]*auto_time[[:space:]]+.*/auto_time 60/' /etc/udhcpd.conf && \
-    sed -i 's/^#*lease_file.*/lease_file \/var\/lib\/misc\/udhcpd.leases/' /etc/udhcpd.conf
-
-RUN touch /var/lib/misc/udhcpd.leases
-
-RUN printf "#!/bin/sh\n\
-udhcpd -f /etc/udhcpd.conf > /var/log/udhcpd.log 2>&1 &\n\
-sleep 1\n\
-if pgrep udhcpd > /dev/null; then\n\
-    echo '[SUCCESS] udhcpd is running.'\n\
-else\n\
-    echo '[ERROR] udhcpd failed to start. Check /var/log/udhcpd.log'\n\
-fi\n\
-" > /usr/local/bin/assign-udhc-start
-
-RUN chmod +x /usr/local/bin/assign-udhc-start
+RUN chmod +x /usr/local/bin/assign-vxlan-start
 
 ################################################################################
 # STEP: Ethernet & VXLAN Infrastructure Orchestration
@@ -330,13 +347,22 @@ RUN chmod +x /usr/local/bin/assign-udhc-start
 #  2. VXLAN Tunneling: Establishes remote L2-over-L3 connectivity.
 #  3. Final Validation: Signals the completion of the network stack.
 ################################################################################
-RUN printf "#!/bin/sh\n\
-/usr/local/bin/assign-mac-start \n\
-/usr/local/bin/assign-bridge-start \n\
-# /usr/local/bin/assign-udhc-start \n\
-echo \"Docker Ethernat Setting Done\n\"\n" > /usr/local/bin/docker-ethernat-start
+RUN printf '#!/bin/sh \n\
+. /usr/local/bin/common-lib.sh \n\
+/usr/local/bin/assign-mac-start && \n\
+/usr/local/bin/assign-bridge-start && \n\
+/usr/local/bin/assign-vxlan-start \n\
+\n\
+RETURN_CODE=$? \n\
+\n\
+[[ $RETURN_CODE -eq 0 ]] && \n\
+    log_system "Docker Ethernat Setting Done" || \n\
+    log_error "docker-ethernet-start error" \n\
+\n\
+return $RETURN_CODE \n\
+' > /usr/local/bin/docker-ethernet-start
 
-RUN chmod +x /usr/local/bin/docker-ethernat-start
+RUN chmod +x /usr/local/bin/docker-ethernet-start
 
 ################################################################################
 # STEP: Master System Entrypoint & Service Orchestration
@@ -346,7 +372,7 @@ RUN chmod +x /usr/local/bin/docker-ethernat-start
 # architectural integrity:
 #
 # Sequence:
-#  1. Infrastructure Layer: Invokes 'docker-ethernat-start' to configure 
+#  1. Infrastructure Layer: Invokes 'docker-ethernet-start' to configure 
 #     local bridges and VXLAN tunnels.
 #  2. Routing Layer: Invokes 'setup-frr-daemons' to launch the core routing 
 #     stack (Zebra, BGP, etc.) once the network substrate is ready.
@@ -356,11 +382,12 @@ RUN chmod +x /usr/local/bin/docker-ethernat-start
 # Design Note: Includes a 'tail -f /dev/null' safety lock to prevent 
 # unexpected container termination.
 ################################################################################
-RUN printf "#!/bin/sh\n\
-/usr/local/bin/docker-ethernat-start \n\
+RUN printf '#!/bin/sh \n\
+/usr/local/bin/docker-ethernet-start && \n\
 /usr/local/bin/setup-frr-daemons \n\
 while true; do /bin/busybox sh ; done \n\
-tail -f /dev/null\n" > /usr/lib/frr/docker-start
+tail -f /dev/null \n\
+' > /usr/lib/frr/docker-start
 
 RUN chmod +x /usr/lib/frr/docker-start
 


### PR DESCRIPTION
#44 Closed

## Description
Changed code clean up and implemented standardized documentation for infrastructure Dockerfiles. This update modularizes network interface provisioning, replaces typo-prone filenames (docker-ethernat-start → docker-ethernet-start), and enhances BGP/EVPN Route Reflector topologies inside the FRRouting stack. Additional network diagnostic packages have been included to monitor real-time traffic.
## Key Features
 * **Clean and Safe Code:** Refactored core network logic into structured, idempotent shell functions (setup_mac, setup_interface_ip) wrapped with robust validation checks to prevent duplicate assignments.
 * **Standardized Logging Library:** Updated common-lib.sh to support detailed log levels (SYSTEM, ACTION, SUCCESS, WARNING) for enhanced execution visibility.
 * **FRRouting Data Plane Optimization:** Shifted iBGP configurations to AS 1, explicitly enabled the isisd daemon, disabled watchfrr for direct container execution control, and enabled route-reflector-client on the Spine/Core nodes.
 * **Package Installation:** Added tcpdump into the base Alpine Linux image to facilitate raw packet capture and control-plane traffic debugging.
## Result
### GNS3

<img width="1069" height="619" alt="image" src="https://github.com/user-attachments/assets/aab174c5-342c-4890-8371-d41232d14ed9" />

### Clean Code && Doc

```dockerfile
################################################################################
# STEP: VXLAN Overlay Network and Bridge Binding Configuration
#
# This script establishes a high-performance VXLAN overlay tunnel (Layer 2 over 
# Layer 3) and integrates it into a local software bridge (br0). It enables 
# seamless, cross-host container communication across distinct physical nodes.
#
# Key Features:
#  - Idempotent VXLAN Provisioning: Avoids interface duplication by validating 
#    pre-existing tunnel endpoints with native 'ip link' checks.
#  - Network Optimization & Acceleration: Explicitly configures UDP checksums 
#    (udpcsum) and disables IPv6 zero checksum constraints (noudp6zerocsumtx/rx) 
#    to drastically reduce encapsulation overhead and boost throughput.
#  - Robust Multi-Component Validation: Ensures that both physical interfaces and 
#    target software bridges exist and are healthy before committing tunnel attachments.
################################################################################
RUN printf '#!/bin/sh \n\
. /usr/local/bin/common-lib.sh \n\
setup_vxlan_leaf() { \n\
    local VTEP_LOCAL_IP=$1 \n\
    local VNI=$2 \n\
    local VXLAN_NAME="vxlan$VNI" \n\
\n\
    log_system "setup_vxlan" \n\
    if ! ip -4 addr show dev lo | grep -F -w "$VTEP_LOCAL_IP" >/dev/null 2>&1; then \n\
        log_warning "Loopback Interface $VTEP_LOCAL_IP not founded" \n\
    fi \n\
    if ip link show "$VXLAN_NAME" >/dev/null 2>&1; then \n\
        log_error "VXLAN $VXLAN_NAME already exists." && return 2 \n\
    fi \n\
    if ! ip link add dev "$VXLAN_NAME" type vxlan \
    id "$VNI" \
    dstport 4789 \
    local "$VTEP_LOCAL_IP" \
    nolearning \
    udpcsum noudp6zerocsumtx noudp6zerocsumrx ; then \n\
        log_error "VXLAN $VXLAN_NAME Created fail" && return 2 \n\
    fi \n\
    log_status "Created vxlan $VXLAN_NAME" \n\
    if ! ip link set dev "$VXLAN_NAME" up; then \n\
        log_error "$VXLAN_NAME set up fail" && return 2 \n\
    fi \n\
    log_success "Setup VXLAN $VXLAN_NAME" \n\
    return 0 \n\
} \n\
setup_vxlan_bridge() { \n\
    local VXLAN_NAME=$1 \n\
    local BR_NAME=$2 \n\
\n\
    log_system "setup_vxlan_bridge" \n\
    if ! ip link show "$VXLAN_NAME" >/dev/null 2>&1; then \n\
        log_error "VXLAN $VXLAN_NAME not founded" && return 2 \n\
    fi \n\
    if ! ip link show "$BR_NAME" >/dev/null 2>&1; then \n\
        log_error "Bridge $BR_NAME not founded" && return 2 \n\
    fi \n\
    if ! ip link set dev "$VXLAN_NAME" master "$BR_NAME"; then \n\
        log_error "Failed to set master $BR_NAME for $VXLAN_NAME"&& return 2  \n\
    fi \n\
    log_success "Setup VXLAN bridge connected $VXLAN_NAME to $BR_NAME" \n\
    return 0 \n\
} \n\
\n\
setup_vxlan_leaf 1.1.1.3 10 && \n\
setup_vxlan_bridge vxlan10 br0 \n\
\n\
RETURN_CODE=$? \n\
\n\
[[ $RETURN_CODE -eq 0 ]] && \n\
    log_system "VXLAN Setting Done" || \n\
    log_error "assign-vxlan-start error" \n\
\n\
return $RETURN_CODE \n\
' > /usr/local/bin/assign-vxlan-start

RUN chmod +x /usr/local/bin/assign-vxlan-start
``
